### PR TITLE
Add Default Weapons

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ All player preferences are automatically saved and persist between disconnects/r
 - **Pistol Round Primary** — Preferred primary weapon for pistol rounds (per-team or shared)
 - **Half-Buy Primary/Secondary** — Preferred weapons for half-buy rounds (per-team or shared)
 - **Full-Buy Primary/Secondary** — Preferred weapons for full-buy rounds (per-team or shared)
+- **Default Weapon Loadouts** - Set default weapon selection based on round type.
 
 #### Spawn Preferences
 - **Spawn Menu Toggle** (`!spawns`) — Whether the CT spawn selection menu is enabled
@@ -190,7 +191,51 @@ Plays 3 pistol rounds, then 2 half-buy, then full-buy for all remaining rounds.
 
 - **Human players:** Get their preferred weapons from the `!guns` menu
 - **Bots:** Get random weapons from the allowed list
-- If a preference isn't available, a random weapon is chosen
+- If a player has no saved preference, the plugin first checks `retakes.weapons.defaults.*`
+- If neither a saved preference nor a configured default is available, a random weapon is chosen
+
+### Default Loadouts
+
+You can define default loadouts that are used before a player chooses their own weapons in `!guns`.
+
+```json
+      "Defaults": {
+        "Pistol": {
+          "Primary": {
+            "T": "weapon_glock",
+            "Ct": "weapon_usp_silencer"
+          },
+          "Secondary": {
+            "T": null,
+            "Ct": null
+          }
+        },
+        "HalfBuy": {
+          "Primary": {
+            "T": "weapon_mac10",
+            "Ct": "weapon_mp7"
+          },
+          "Secondary": {
+            "T": "weapon_deagle",
+            "Ct": "weapon_deagle"
+          }
+        },
+        "FullBuy": {
+          "Primary": {
+            "T": "weapon_ak47",
+            "Ct": "weapon_m4a1"
+          },
+          "Secondary": {
+            "T": "weapon_deagle",
+            "Ct": "weapon_deagle"
+          }
+        }
+      }
+```
+
+- `pistol`, `halfBuy`, and `fullBuy` all support `primary`
+- `halfBuy` and `fullBuy` also support `secondary`
+- Player selections still override these defaults and remain persisted through Cookies
 
 ### Grenades
 

--- a/src/Configuration/WeaponsConfig.cs
+++ b/src/Configuration/WeaponsConfig.cs
@@ -7,6 +7,8 @@ public sealed class WeaponsConfig
 {
   public bool BuyMenuEnabled { get; set; } = true;
 
+  public DefaultWeaponsConfig Defaults { get; set; } = new();
+
   public List<string> Pistols { get; set; } = new()
   {
     "weapon_glock",
@@ -32,6 +34,34 @@ public sealed class WeaponsConfig
     T = new() { "weapon_ak47", "weapon_sg556" },
     Ct = new() { "weapon_m4a1", "weapon_m4a1_silencer", "weapon_aug" },
   };
+}
+
+/// <summary>
+/// Configuration for server-defined default loadouts when players have no saved preference yet.
+/// </summary>
+public sealed class DefaultWeaponsConfig
+{
+  public DefaultRoundLoadoutConfig Pistol { get; set; } = new();
+  public DefaultRoundLoadoutConfig HalfBuy { get; set; } = new();
+  public DefaultRoundLoadoutConfig FullBuy { get; set; } = new();
+}
+
+/// <summary>
+/// Default loadout for a given round type.
+/// </summary>
+public sealed class DefaultRoundLoadoutConfig
+{
+  public DefaultWeaponSelectionConfig Primary { get; set; } = new();
+  public DefaultWeaponSelectionConfig Secondary { get; set; } = new();
+}
+
+/// <summary>
+/// Team-aware default weapon selection.
+/// </summary>
+public sealed class DefaultWeaponSelectionConfig
+{
+  public string? T { get; set; }
+  public string? Ct { get; set; }
 }
 
 /// <summary>

--- a/src/Handlers/CommandHandlers.cs
+++ b/src/Handlers/CommandHandlers.cs
@@ -971,7 +971,8 @@ public sealed class CommandHandlers
   {
     var isCt = (Team)player.Controller.TeamNum == Team.CT;
     var selected = _prefs.GetPistolPrimary(player.SteamID, isCt);
-    var selectedText = WeaponOrRandom(selected);
+    var defaultWeapon = ResolveDefaultWeapon(RoundType.Pistol, isCt, isPrimary: true);
+    var selectedText = SelectedOrFallback(selected, defaultWeapon);
 
     var builder = core.MenusAPI.CreateBuilder()
       .Design.SetMenuTitle($"Pistols: Primary {selectedText}")
@@ -990,7 +991,7 @@ public sealed class CommandHandlers
       builder.AddOption(opt);
     }
 
-    var clear = new ButtonMenuOption("Clear (random)");
+    var clear = new ButtonMenuOption(DefaultLabel(defaultWeapon));
     clear.Click += async (_, args) =>
     {
       var ct = (Team)args.Player.Controller.TeamNum == Team.CT;
@@ -1010,14 +1011,16 @@ public sealed class CommandHandlers
       ? _prefs.GetFullBuyPack(player.SteamID, isCt)
       : _prefs.GetHalfBuyPack(player.SteamID, isCt);
 
-    var primaryText = WeaponOrRandom(pack.Primary);
-    var secondaryText = WeaponOrRandom(pack.Secondary);
+    var defaultPrimary = ResolveDefaultWeapon(roundType, isCt, isPrimary: true);
+    var defaultSecondary = ResolveDefaultWeapon(roundType, isCt, isPrimary: false);
+    var primaryText = SelectedOrFallback(pack.Primary, defaultPrimary);
+    var secondaryText = SelectedOrFallback(pack.Secondary, defaultSecondary);
 
     var primary = new SubmenuMenuOption($"Primary: {primaryText}", () => BuildPackSlotMenu(core, player, roundType, isPrimary: true));
     var secondary = new SubmenuMenuOption($"Secondary: {secondaryText}", () => BuildPackSlotMenu(core, player, roundType, isPrimary: false));
 
     return core.MenusAPI.CreateBuilder()
-      .Design.SetMenuTitle(PackTitle(roundType, pack.Primary, pack.Secondary))
+      .Design.SetMenuTitle(PackTitle(roundType, pack.Primary, pack.Secondary, defaultPrimary, defaultSecondary))
       .EnableSound()
       .AddOption(primary)
       .AddOption(secondary)
@@ -1058,7 +1061,8 @@ public sealed class CommandHandlers
       builder.AddOption(opt);
     }
 
-    var clear = new ButtonMenuOption("Clear (random)");
+    var defaultWeapon = ResolveDefaultWeapon(roundType, isCt, isPrimary);
+    var clear = new ButtonMenuOption(DefaultLabel(defaultWeapon));
     clear.Click += async (_, args) =>
     {
       var ct = (Team)args.Player.Controller.TeamNum == Team.CT;
@@ -1079,6 +1083,37 @@ public sealed class CommandHandlers
     builder.AddOption(clear);
 
     return builder.Build();
+  }
+
+  private string? ResolveDefaultWeapon(RoundType roundType, bool isCt, bool isPrimary)
+  {
+    var team = isCt ? Team.CT : Team.T;
+    var defaults = roundType switch
+    {
+      RoundType.Pistol => _config.Config.Weapons.Defaults.Pistol,
+      RoundType.HalfBuy => _config.Config.Weapons.Defaults.HalfBuy,
+      RoundType.FullBuy => _config.Config.Weapons.Defaults.FullBuy,
+      _ => null,
+    };
+
+    if (defaults is null)
+    {
+      return null;
+    }
+
+    var selection = isPrimary ? defaults.Primary : defaults.Secondary;
+    return ResolveDefaultWeaponSelection(selection, team);
+  }
+
+  private static string? ResolveDefaultWeaponSelection(DefaultWeaponSelectionConfig selection, Team team)
+  {
+    if (team == Team.CT && !string.IsNullOrWhiteSpace(selection.Ct))
+      return selection.Ct;
+
+    if (team == Team.T && !string.IsNullOrWhiteSpace(selection.T))
+      return selection.T;
+
+    return null;
   }
 
   private List<string> GetAllowedWeaponsForMenu(RoundType roundType, bool isCt, bool isPrimary)
@@ -1156,26 +1191,32 @@ public sealed class CommandHandlers
     ["weapon_elite"] = "Dual Berettas",
   };
 
-  private static string WeaponOrRandom(string? weapon)
+  private static string SelectedOrFallback(string? weapon, string? defaultWeapon)
   {
-    if (string.IsNullOrWhiteSpace(weapon)) return "(random)";
+    if (string.IsNullOrWhiteSpace(weapon))
+      return string.IsNullOrWhiteSpace(defaultWeapon) ? "(random)" : WeaponDisplayName(defaultWeapon);
+
     return WeaponDisplayName(weapon);
   }
 
-  private static string PackSummary(string label, string? primary, string? secondary)
+  private static string PackTitle(RoundType roundType, string? primary, string? secondary, string? defaultPrimary, string? defaultSecondary)
   {
     if (string.IsNullOrWhiteSpace(primary) && string.IsNullOrWhiteSpace(secondary))
-      return $"{label}: (random)";
+    {
+      if (string.IsNullOrWhiteSpace(defaultPrimary) && string.IsNullOrWhiteSpace(defaultSecondary))
+        return $"{roundType}: (random)";
 
-    return $"{label}: {WeaponOrRandom(primary)} + {WeaponOrRandom(secondary)}";
+      return $"{roundType}: {SelectedOrFallback(null, defaultPrimary)} + {SelectedOrFallback(null, defaultSecondary)}";
+    }
+
+    return $"{roundType}: {SelectedOrFallback(primary, defaultPrimary)} + {SelectedOrFallback(secondary, defaultSecondary)}";
   }
 
-  private static string PackTitle(RoundType roundType, string? primary, string? secondary)
+  private static string DefaultLabel(string? defaultWeapon)
   {
-    if (string.IsNullOrWhiteSpace(primary) && string.IsNullOrWhiteSpace(secondary))
-      return $"{roundType}: (random)";
-
-    return $"{roundType}: {WeaponOrRandom(primary)} + {WeaponOrRandom(secondary)}";
+    return string.IsNullOrWhiteSpace(defaultWeapon)
+      ? "Default (random)"
+      : $"Default ({WeaponDisplayName(defaultWeapon)})";
   }
 
   private static string WeaponDisplayName(string weapon)

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -312,20 +312,23 @@ public sealed class AllocationService : IAllocationService
     {
       var allowed = _config.Config.Weapons.Pistols;
       var preferred = _prefs.GetPistolPrimary(steamId, team == Team.CT);
-      return PreferOrRandom(preferred, allowed);
+      var configuredDefault = GetConfiguredDefaultPrimary(team, roundType);
+      return PreferOrDefaultOrRandom(preferred, configuredDefault, allowed);
     }
 
     if (roundType == RoundType.HalfBuy)
     {
       var allowed = GetAllowedPrimaryWeapons(roundType, team);
       var pack = _prefs.GetHalfBuyPack(steamId, team == Team.CT);
-      return PreferOrRandom(pack.Primary, allowed);
+      var configuredDefault = GetConfiguredDefaultPrimary(team, roundType);
+      return PreferOrDefaultOrRandom(pack.Primary, configuredDefault, allowed);
     }
 
     // FullBuy
     var fullAllowed = GetAllowedPrimaryWeapons(roundType, team);
     var fullPack = _prefs.GetFullBuyPack(steamId, team == Team.CT);
-    return PreferOrRandom(fullPack.Primary, fullAllowed);
+    var fullConfiguredDefault = GetConfiguredDefaultPrimary(team, roundType);
+    return PreferOrDefaultOrRandom(fullPack.Primary, fullConfiguredDefault, fullAllowed);
   }
 
   private string? SelectSecondary(Team team, RoundType roundType, ulong steamId)
@@ -336,14 +339,52 @@ public sealed class AllocationService : IAllocationService
     if (roundType == RoundType.HalfBuy)
     {
       var pack = _prefs.GetHalfBuyPack(steamId, team == Team.CT);
-      return PreferOrRandom(pack.Secondary, allowed);
+      var configuredDefault = GetConfiguredDefaultSecondary(team, roundType);
+      return PreferOrDefaultOrRandom(pack.Secondary, configuredDefault, allowed);
     }
 
     if (roundType == RoundType.FullBuy)
     {
       var pack = _prefs.GetFullBuyPack(steamId, team == Team.CT);
-      return PreferOrRandom(pack.Secondary, allowed);
+      var configuredDefault = GetConfiguredDefaultSecondary(team, roundType);
+      return PreferOrDefaultOrRandom(pack.Secondary, configuredDefault, allowed);
     }
+
+    return null;
+  }
+
+  private string? GetConfiguredDefaultPrimary(Team team, RoundType roundType)
+  {
+    var defaults = roundType switch
+    {
+      RoundType.Pistol => _config.Config.Weapons.Defaults.Pistol,
+      RoundType.HalfBuy => _config.Config.Weapons.Defaults.HalfBuy,
+      RoundType.FullBuy => _config.Config.Weapons.Defaults.FullBuy,
+      _ => null,
+    };
+
+    return defaults is null ? null : ResolveSelection(defaults.Primary, team);
+  }
+
+  private string? GetConfiguredDefaultSecondary(Team team, RoundType roundType)
+  {
+    var defaults = roundType switch
+    {
+      RoundType.HalfBuy => _config.Config.Weapons.Defaults.HalfBuy,
+      RoundType.FullBuy => _config.Config.Weapons.Defaults.FullBuy,
+      _ => null,
+    };
+
+    return defaults is null ? null : ResolveSelection(defaults.Secondary, team);
+  }
+
+  private static string? ResolveSelection(DefaultWeaponSelectionConfig selection, Team team)
+  {
+    if (team == Team.CT && !string.IsNullOrWhiteSpace(selection.Ct))
+      return selection.Ct;
+
+    if (team == Team.T && !string.IsNullOrWhiteSpace(selection.T))
+      return selection.T;
 
     return null;
   }
@@ -476,11 +517,16 @@ public sealed class AllocationService : IAllocationService
     return selected;
   }
 
-  private string? PreferOrRandom(string? preferred, IReadOnlyList<string> allowed)
+  private string? PreferOrDefaultOrRandom(string? preferred, string? configuredDefault, IReadOnlyList<string> allowed)
   {
     if (!string.IsNullOrWhiteSpace(preferred) && IsAllowed(preferred, allowed))
     {
       return preferred;
+    }
+
+    if (!string.IsNullOrWhiteSpace(configuredDefault) && IsAllowed(configuredDefault, allowed))
+    {
+      return configuredDefault;
     }
 
     return allowed.Count == 0 ? null : allowed[_random.Next(allowed.Count)];

--- a/src/Services/RetakesConfigService.cs
+++ b/src/Services/RetakesConfigService.cs
@@ -112,6 +112,7 @@ public sealed class RetakesConfigService : IRetakesConfigService
       EnsureSmokeScenariosConfigPresent();
       EnsureSoloBotConfigPresent();
       EnsureAfkManagerConfigPresent();
+      EnsureWeaponDefaultsConfigPresent();
       ApplyLoggingToggles(Config.Server);
     }
     catch (Exception ex)
@@ -347,6 +348,103 @@ public sealed class RetakesConfigService : IRetakesConfigService
     {
       _logger.LogPluginWarning(ex, "Retakes: failed to ensure AfkManager exists in config.json");
     }
+  }
+
+  private void EnsureWeaponDefaultsConfigPresent()
+  {
+    try
+    {
+      if (!File.Exists(_path))
+      {
+        return;
+      }
+
+      var text = File.ReadAllText(_path);
+      if (string.IsNullOrWhiteSpace(text))
+      {
+        return;
+      }
+
+      var rootNode = JsonNode.Parse(text);
+      if (rootNode is not JsonObject rootObj)
+      {
+        return;
+      }
+
+      ConfigSanitizer.SanitizeColonDelimitedKeys(rootObj);
+      ConfigSanitizer.SanitizeCaseInsensitiveDuplicateKeys(rootObj);
+
+      if (rootObj[SectionName] is not JsonObject sectionObj)
+      {
+        sectionObj = new JsonObject();
+        rootObj[SectionName] = sectionObj;
+      }
+
+      var weaponsKey = sectionObj.ContainsKey("Weapons") ? "Weapons"
+        : sectionObj.ContainsKey("weapons") ? "weapons"
+        : "Weapons";
+
+      if (sectionObj[weaponsKey] is not JsonObject weaponsObj)
+      {
+        weaponsObj = new JsonObject();
+        sectionObj[weaponsKey] = weaponsObj;
+      }
+
+      var defaultsKey = weaponsObj.ContainsKey("Defaults") ? "Defaults"
+        : weaponsObj.ContainsKey("defaults") ? "defaults"
+        : "Defaults";
+
+      if (weaponsObj[defaultsKey] is not JsonObject defaultsObj)
+      {
+        defaultsObj = new JsonObject();
+        weaponsObj[defaultsKey] = defaultsObj;
+      }
+
+      EnsureDefaultRoundLoadout(defaultsObj, "Pistol", "pistol", Config.Weapons.Defaults.Pistol);
+      EnsureDefaultRoundLoadout(defaultsObj, "HalfBuy", "halfBuy", Config.Weapons.Defaults.HalfBuy);
+      EnsureDefaultRoundLoadout(defaultsObj, "FullBuy", "fullBuy", Config.Weapons.Defaults.FullBuy);
+
+      var updated = rootObj.ToJsonString(JsonOptions);
+      File.WriteAllText(_path, updated);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogPluginWarning(ex, "Retakes: failed to ensure weapon defaults exist in config.json");
+    }
+  }
+
+  private static void EnsureDefaultRoundLoadout(JsonObject parent, string pascalName, string camelName, DefaultRoundLoadoutConfig defaults)
+  {
+    var roundKey = parent.ContainsKey(pascalName) ? pascalName
+      : parent.ContainsKey(camelName) ? camelName
+      : pascalName;
+
+    if (parent[roundKey] is not JsonObject roundObj)
+    {
+      roundObj = new JsonObject();
+      parent[roundKey] = roundObj;
+    }
+
+    EnsureDefaultWeaponSelection(roundObj, "Primary", "primary", defaults.Primary);
+    EnsureDefaultWeaponSelection(roundObj, "Secondary", "secondary", defaults.Secondary);
+  }
+
+  private static void EnsureDefaultWeaponSelection(JsonObject parent, string pascalName, string camelName, DefaultWeaponSelectionConfig defaults)
+  {
+    var selectionKey = parent.ContainsKey(pascalName) ? pascalName
+      : parent.ContainsKey(camelName) ? camelName
+      : pascalName;
+
+    if (parent[selectionKey] is not JsonObject selectionObj)
+    {
+      selectionObj = new JsonObject();
+      parent[selectionKey] = selectionObj;
+    }
+
+    string Key(string pascal, string camel) => selectionObj.ContainsKey(pascal) ? pascal : selectionObj.ContainsKey(camel) ? camel : pascal;
+
+    if (selectionObj[Key("T", "t")] is null) selectionObj[Key("T", "t")] = defaults.T;
+    if (selectionObj[Key("Ct", "ct")] is null) selectionObj[Key("Ct", "ct")] = defaults.Ct;
   }
 
   public void Save()


### PR DESCRIPTION
This pull request add support for servers to set a predefined set of weapons that users will automatically receive based on round type. If a user decides to change their weapons the plugin will use those instead.

I wasn't a huge fan of random weapons by default and this gives a good starting loadout that players can customize. If you do not set a loadout in the config we just fallback to the prior implementation which was random weapons.

I did change the guns menu wording to use "Default" instead of Clear. I felt it made more sense considering we don't technically clear their selection. If you'd like I can change it so that we keep the "Clear" wording unless they have default weapons set in the config and then we use "Default". 

Tested on Linux with `SwiftlyS2: 1.2.2`

Let me know if you have any questions or changes you'd like made! 