### PR TITLE
feat: Easier to change guns and many bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The plugin automatically gives players weapons, armor, and grenades each round. 
 
 | Round Type | Armor | Primary | Secondary | Grenades | CT Defuser |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **Pistol** | Kevlar | Pistols | ❌ | Flash or smoke | 1 random player |
+| **Pistol** | Kevlar (no helmet by default) | Pistols | ❌ | Flash or smoke | 1 random player |
 | **Half-Buy** | Kevlar + Helmet | SMGs/Budget rifles | ✅ Pistol | Smoke + 1-2 more | Everyone |
 | **Full-Buy** | Kevlar + Helmet | Rifles (or AWP/Scout) | ✅ Pistol | Smoke + 1-2 more | Everyone |
 
@@ -208,6 +208,7 @@ Plays 3 pistol rounds, then 2 half-buy, then full-buy for all remaining rounds.
 | `retakes.allocation.stripWeapons` | `true` | Remove old weapons before giving new ones |
 | `retakes.allocation.givePistolOnRifleRounds` | `true` | Give secondary pistol on half/full-buy rounds |
 | `retakes.allocation.instantSwap` | `true` | Instantly swap weapons in-hand when a player changes preference mid-round via `!guns` or `!gun` |
+| `retakes.allocation.pistolHelmet` | `false` | Give helmet (kevlar + helmet) on pistol rounds. When `false`, players only receive kevlar |
 | `retakes.preferences.usePerTeamPreferences` | `false` | Separate T/CT weapon preferences in `!guns` menu |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Plays 3 pistol rounds, then 2 half-buy, then full-buy for all remaining rounds.
 | `retakes.allocation.enabled` | `true` | Enable/disable weapon allocation |
 | `retakes.allocation.stripWeapons` | `true` | Remove old weapons before giving new ones |
 | `retakes.allocation.givePistolOnRifleRounds` | `true` | Give secondary pistol on half/full-buy rounds |
+| `retakes.allocation.instantSwap` | `true` | Instantly swap weapons in-hand when a player changes preference mid-round via `!guns` or `!gun` |
 | `retakes.preferences.usePerTeamPreferences` | `false` | Separate T/CT weapon preferences in `!guns` menu |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -306,11 +306,33 @@ Each map file contains the spawns used by the retakes allocator.
 
 | Command | Description |
 | :--- | :--- |
-| `!guns` / `!gun` | Opens the weapon preference menu. |
+| `!guns` | Opens the weapon preference menu. |
+| `!gun <weapon>` | Quickly sets your preferred weapon via chat (see [Quick Weapon Select](#quick-weapon-select-gun) below). |
 | `!retake` | Opens the main Retakes menu (spawn preference, AWP, etc.). |
 | `!spawns` | Toggles the spawn selection menu. |
 | `!awp` | Toggles AWP preference. |
 | `!voices` | Toggles voice announcements. |
+
+### Quick Weapon Select (`!gun`)
+
+Type `!gun <weapon>` in chat to change your weapon preference **instantly** — no menu needed. The weapon is saved to your preferences and swapped in-hand immediately.
+
+**Accepted input formats:**
+- Entity names: `weapon_ak47`, `weapon_m4a1_silencer`
+- Short names: `ak`, `ak47`, `deag`, `usp`, `m4a1s`, `scout`, `famas`, `galil`, `p250`, `cz`, `57`, `r8`, etc.
+- Display names: `AK-47`, `M4A1-S`, `USP-S`
+
+**Behaviour:**
+- Validates the weapon against the **current round type** (Pistol / HalfBuy / FullBuy)
+- Automatically assigns to the correct slot (primary or secondary)
+- Tells you if the weapon isn't allowed this round or is already your preference
+
+**Examples:**
+```
+!gun ak        → sets AK-47 as your full-buy/half-buy primary
+!gun usp       → sets USP-S as your secondary (or pistol-round weapon)
+!gun m4a1s     → sets M4A1-S as your CT primary
+```
 
 ### Debug
 

--- a/resources/translations/en.jsonc
+++ b/resources/translations/en.jsonc
@@ -88,6 +88,14 @@
   "command.awp.enabled": "[green]Retakes:[white] AWP preference enabled",
   "command.awp.disabled": "[green]Retakes:[white] AWP preference disabled",
 
+  "command.gun.usage": "[green]Retakes:[white] Usage: !gun <weapon_name>",
+  "command.gun.no_round": "[green]Retakes:[white] No round in progress.",
+  "command.gun.not_allowed": "[green]Retakes:[white] {0} is not allowed during {1} rounds.",
+  "command.gun.set": "[green]Retakes:[white] Set [orange]{0}[white] as your [orange]{1}[white] weapon.",
+  "command.gun.set_primary": "[green]Retakes:[white] Set [orange]{0}[white] as your [orange]{1}[white] primary.",
+  "command.gun.set_secondary": "[green]Retakes:[white] Set [orange]{0}[white] as your [orange]{1}[white] secondary.",
+  "command.gun.already_set": "[green]Retakes:[white] [orange]{0}[white] is already your preferred weapon.",
+
   "command.reloadcfg.success": "[green]Retakes:[white] reloaded config.json",
   "command.reloadcfg.failed": "[green]Retakes:[white] failed to reload config.json",
 

--- a/resources/translations/lt.jsonc
+++ b/resources/translations/lt.jsonc
@@ -88,6 +88,14 @@
   "command.awp.enabled": "[green]Retakes:[white] AWP preferencija įjungta",
   "command.awp.disabled": "[green]Retakes:[white] AWP preferencija išjungta",
 
+  "command.gun.usage": "[green]Retakes:[white] Naudojimas: !gun <ginklo_pavadinimas>",
+  "command.gun.no_round": "[green]Retakes:[white] Nėra aktyvaus raundo.",
+  "command.gun.not_allowed": "[green]Retakes:[white] {0} neleidžiamas {1} raunduose.",
+  "command.gun.set": "[green]Retakes:[white] Nustatytas [orange]{0}[white] kaip tavo [orange]{1}[white] ginklas.",
+  "command.gun.set_primary": "[green]Retakes:[white] Nustatytas [orange]{0}[white] kaip tavo [orange]{1}[white] pagrindinis ginklas.",
+  "command.gun.set_secondary": "[green]Retakes:[white] Nustatytas [orange]{0}[white] kaip tavo [orange]{1}[white] šalutinis ginklas.",
+  "command.gun.already_set": "[green]Retakes:[white] [orange]{0}[white] jau yra tavo pasirinktas ginklas.",
+
   "command.reloadcfg.success": "[green]Retakes:[white] perkrautas config.json",
   "command.reloadcfg.failed": "[green]Retakes:[white] nepavyko perkrauti config.json",
 

--- a/resources/translations/pt-BR.jsonc
+++ b/resources/translations/pt-BR.jsonc
@@ -88,6 +88,14 @@
   "command.awp.enabled": "[green]Retakes:[white] preferência de AWP ativada",
   "command.awp.disabled": "[green]Retakes:[white] preferência de AWP desativada",
 
+  "command.gun.usage": "[green]Retakes:[white] Use: !gun <nome_da_arma>",
+  "command.gun.no_round": "[green]Retakes:[white] Nenhum round em andamento.",
+  "command.gun.not_allowed": "[green]Retakes:[white] {0} não é permitido durante rounds {1}.",
+  "command.gun.set": "[green]Retakes:[white] Definido [orange]{0}[white] como sua arma de [orange]{1}[white].",
+  "command.gun.set_primary": "[green]Retakes:[white] Definido [orange]{0}[white] como sua primária de [orange]{1}[white].",
+  "command.gun.set_secondary": "[green]Retakes:[white] Definido [orange]{0}[white] como sua secundária de [orange]{1}[white].",
+  "command.gun.already_set": "[green]Retakes:[white] [orange]{0}[white] já é sua arma preferida.",
+
   "command.reloadcfg.success": "[green]Retakes:[white] config.json recarregado",
   "command.reloadcfg.failed": "[green]Retakes:[white] falha ao recarregar config.json",
 

--- a/src/Configuration/AllocationConfig.cs
+++ b/src/Configuration/AllocationConfig.cs
@@ -28,5 +28,7 @@ public sealed class AllocationConfig
   public string AwpPriorityFlag { get; set; } = "";
   public int AwpPriorityPct { get; set; } = 0;
 
+  public bool PistolHelmet { get; set; } = false;
+
   public bool InstantSwap { get; set; } = true;
 }

--- a/src/Configuration/AllocationConfig.cs
+++ b/src/Configuration/AllocationConfig.cs
@@ -27,4 +27,6 @@ public sealed class AllocationConfig
 
   public string AwpPriorityFlag { get; set; } = "";
   public int AwpPriorityPct { get; set; } = 0;
+
+  public bool InstantSwap { get; set; } = true;
 }

--- a/src/Handlers/CommandHandlers.cs
+++ b/src/Handlers/CommandHandlers.cs
@@ -988,6 +988,8 @@ public sealed class CommandHandlers
       {
         var ct = (Team)args.Player.Controller.TeamNum == Team.CT;
         _prefs.SetPistolPrimary(args.Player.SteamID, ct, w);
+        if (_allocation.InstantSwapEnabled && _allocation.CurrentRoundType == RoundType.Pistol)
+          ReplaceWeaponInSlot(args.Player, w, isPistolSlot: true);
         core.MenusAPI.OpenMenuForPlayer(args.Player, BuildPistolMenu(core, args.Player));
         await ValueTask.CompletedTask;
       };
@@ -1055,6 +1057,9 @@ public sealed class CommandHandlers
           if (isPrimary) _prefs.SetHalfBuyPrimary(args.Player.SteamID, ct, w);
           else _prefs.SetHalfBuySecondary(args.Player.SteamID, ct, w);
         }
+
+        if (_allocation.InstantSwapEnabled && _allocation.CurrentRoundType == roundType)
+          ReplaceWeaponInSlot(args.Player, w, isPistolSlot: !isPrimary);
 
         core.MenusAPI.OpenMenuForPlayer(args.Player, BuildRoundPackMenu(core, args.Player, roundType));
         await ValueTask.CompletedTask;
@@ -1350,7 +1355,8 @@ public sealed class CommandHandlers
           return;
         }
         _prefs.SetPistolPrimary(steamId, isCt, canonicalName);
-        ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
+        if (_allocation.InstantSwapEnabled)
+          ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
         context.Reply(Tr(context, "command.gun.set", displayName, "Pistol"));
         break;
 
@@ -1371,7 +1377,8 @@ public sealed class CommandHandlers
             _prefs.SetHalfBuyPrimary(steamId, isCt, canonicalName);
           else
             _prefs.SetFullBuyPrimary(steamId, isCt, canonicalName);
-          ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: false);
+          if (_allocation.InstantSwapEnabled)
+            ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: false);
           context.Reply(Tr(context, "command.gun.set_primary", displayName, roundLabel));
         }
         else if (isPistol)
@@ -1388,7 +1395,8 @@ public sealed class CommandHandlers
             _prefs.SetHalfBuySecondary(steamId, isCt, canonicalName);
           else
             _prefs.SetFullBuySecondary(steamId, isCt, canonicalName);
-          ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
+          if (_allocation.InstantSwapEnabled)
+            ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
           context.Reply(Tr(context, "command.gun.set_secondary", displayName, roundLabel));
         }
         else

--- a/src/Handlers/CommandHandlers.cs
+++ b/src/Handlers/CommandHandlers.cs
@@ -3,6 +3,7 @@ using SwiftlyS2.Shared.Commands;
 using SwiftlyS2.Shared.Menus;
 using SwiftlyS2.Shared.Natives;
 using SwiftlyS2.Shared.Players;
+using SwiftlyS2.Shared.SchemaDefinitions;
 using SwiftlyS2.Core.Menus.OptionsBase;
 using SwiftlyS2_Retakes.Configuration;
 using SwiftlyS2_Retakes.Constants;
@@ -28,6 +29,7 @@ public sealed class CommandHandlers
   private readonly IPlayerPreferencesService _prefs;
   private readonly IRetakesConfigService _config;
   private readonly ISmokeScenarioService _smokeScenario;
+  private readonly IAllocationService _allocation;
 
   private readonly List<Guid> _commandGuids = new();
 
@@ -39,7 +41,8 @@ public sealed class CommandHandlers
     IRetakesStateService state,
     IPlayerPreferencesService prefs,
     IRetakesConfigService config,
-    ISmokeScenarioService smokeScenario
+    ISmokeScenarioService smokeScenario,
+    IAllocationService allocation
   )
   {
     _mapConfig = mapConfig;
@@ -50,6 +53,7 @@ public sealed class CommandHandlers
     _prefs = prefs;
     _config = config;
     _smokeScenario = smokeScenario;
+    _allocation = allocation;
   }
 
   public void Register(ISwiftlyCore core)
@@ -82,7 +86,7 @@ public sealed class CommandHandlers
     _commandGuids.Add(core.Command.RegisterCommand("voices", Voices, registerRaw: true));
 
     _commandGuids.Add(core.Command.RegisterCommand("guns", Guns, registerRaw: true));
-    _commandGuids.Add(core.Command.RegisterCommand("gun", Guns, registerRaw: true));
+    _commandGuids.Add(core.Command.RegisterCommand("gun", SelectGun, registerRaw: true));
     _commandGuids.Add(core.Command.RegisterCommand("retake", Retake, registerRaw: true));
     _commandGuids.Add(core.Command.RegisterCommand("spawns", Spawns, registerRaw: true));
     _commandGuids.Add(core.Command.RegisterCommand("awp", Awp, registerRaw: true));
@@ -1190,6 +1194,228 @@ public sealed class CommandHandlers
     // Known weird cases should be added to WeaponNameOverrides.
     return string.Join(' ', s.Split(' ', StringSplitOptions.RemoveEmptyEntries)
       .Select(part => part.Length == 0 ? part : char.ToUpperInvariant(part[0]) + part[1..]));
+  }
+
+  /// <summary>
+  /// Resolves user input to a weapon_ entity name.
+  /// Accepts: weapon_ak47, ak47, AK-47, m4a1-s, M4A1-S, usp, deagle, etc.
+  /// </summary>
+  private static string ResolveWeaponName(string input)
+  {
+    // Already a weapon_ name — use as-is
+    if (input.StartsWith("weapon_", StringComparison.OrdinalIgnoreCase))
+      return input;
+
+    // Check common player aliases first
+    if (WeaponAliases.TryGetValue(input, out var alias))
+      return alias;
+
+    // Try reverse lookup: match input against display names (e.g. "M4A1-S" → "weapon_m4a1_silencer")
+    foreach (var kvp in WeaponNameOverrides)
+    {
+      if (kvp.Value.Equals(input, StringComparison.OrdinalIgnoreCase))
+        return kvp.Key;
+    }
+
+    // Try matching display name with spaces/hyphens removed (e.g. "m4a1s" matches "M4A1-S")
+    var normalized = input.Replace("-", "").Replace(" ", "");
+    if (WeaponAliases.TryGetValue(normalized, out var normalizedAlias))
+      return normalizedAlias;
+
+    foreach (var kvp in WeaponNameOverrides)
+    {
+      var normalizedDisplay = kvp.Value.Replace("-", "").Replace(" ", "");
+      if (normalizedDisplay.Equals(normalized, StringComparison.OrdinalIgnoreCase))
+        return kvp.Key;
+    }
+
+    // Fallback: prepend weapon_ prefix
+    return $"weapon_{input}";
+  }
+
+  private static readonly Dictionary<string, string> WeaponAliases = new(StringComparer.OrdinalIgnoreCase)
+  {
+    // M4 variants
+    ["m4"] = "weapon_m4a1",
+    ["m4a4"] = "weapon_m4a1",
+    ["m4a1"] = "weapon_m4a1_silencer",
+    ["m4a1s"] = "weapon_m4a1_silencer",
+    ["m4a1_s"] = "weapon_m4a1_silencer",
+    ["m4s"] = "weapon_m4a1_silencer",
+    // USP
+    ["usp"] = "weapon_usp_silencer",
+    ["usps"] = "weapon_usp_silencer",
+    ["usp_s"] = "weapon_usp_silencer",
+    // Common shorthands
+    ["deag"] = "weapon_deagle",
+    ["deagle"] = "weapon_deagle",
+    ["ak"] = "weapon_ak47",
+    ["glock"] = "weapon_glock",
+    ["awp"] = "weapon_awp",
+    ["scout"] = "weapon_ssg08",
+    ["ssg"] = "weapon_ssg08",
+    ["galil"] = "weapon_galilar",
+    ["famas"] = "weapon_famas",
+    ["aug"] = "weapon_aug",
+    ["sg553"] = "weapon_sg556",
+    ["krieg"] = "weapon_sg556",
+    ["mac10"] = "weapon_mac10",
+    ["mp7"] = "weapon_mp7",
+    ["mp9"] = "weapon_mp9",
+    ["mp5"] = "weapon_mp5sd",
+    ["ump"] = "weapon_ump45",
+    ["p90"] = "weapon_p90",
+    ["bizon"] = "weapon_bizon",
+    ["p250"] = "weapon_p250",
+    ["cz"] = "weapon_cz75a",
+    ["cz75"] = "weapon_cz75a",
+    ["tec9"] = "weapon_tec9",
+    ["fiveseven"] = "weapon_fiveseven",
+    ["57"] = "weapon_fiveseven",
+    ["revolver"] = "weapon_revolver",
+    ["r8"] = "weapon_revolver",
+    ["dualies"] = "weapon_elite",
+    ["elite"] = "weapon_elite",
+    ["nova"] = "weapon_nova",
+    ["xm"] = "weapon_xm1014",
+    ["mag7"] = "weapon_mag7",
+    ["negev"] = "weapon_negev",
+    ["m249"] = "weapon_m249",
+    ["p2000"] = "weapon_hkp2000",
+  };
+
+  private void SelectGun(ICommandContext context)
+  {
+    if (!context.IsSentByPlayer || context.Sender is null)
+    {
+      context.Reply(Tr(context, "error.must_be_player"));
+      return;
+    }
+
+    if (context.Args.Length < 1)
+    {
+      context.Reply(Tr(context, "command.gun.usage"));
+      return;
+    }
+
+    var roundType = _allocation.CurrentRoundType;
+    if (roundType is null)
+    {
+      context.Reply(Tr(context, "command.gun.no_round"));
+      return;
+    }
+
+    var input = context.Args[0].Trim();
+    var weaponName = ResolveWeaponName(input);
+
+    var player = context.Sender;
+    var isCt = (Team)player.Controller.TeamNum == Team.CT;
+    var weapons = _config.Config.Weapons;
+    var pistols = weapons.Pistols;
+
+    // Check if weapon is a pistol
+    var isPistol = pistols.Any(p => p.Equals(weaponName, StringComparison.OrdinalIgnoreCase));
+
+    // Get allowed primaries for current round type
+    var allowedPrimaries = GetAllowedWeaponsForMenu(roundType.Value, isCt, isPrimary: true);
+    var isPrimary = allowedPrimaries.Any(p => p.Equals(weaponName, StringComparison.OrdinalIgnoreCase));
+
+    // Resolve canonical weapon name from the config lists
+    string? canonicalName = null;
+    if (isPistol)
+      canonicalName = pistols.FirstOrDefault(p => p.Equals(weaponName, StringComparison.OrdinalIgnoreCase));
+    if (isPrimary)
+      canonicalName = allowedPrimaries.FirstOrDefault(p => p.Equals(weaponName, StringComparison.OrdinalIgnoreCase));
+
+    if (canonicalName is null)
+    {
+      context.Reply(Tr(context, "command.gun.not_allowed", WeaponDisplayName(weaponName), roundType.Value));
+      return;
+    }
+
+    var displayName = WeaponDisplayName(canonicalName);
+    var steamId = player.SteamID;
+
+    switch (roundType.Value)
+    {
+      case RoundType.Pistol:
+        if (!isPistol)
+        {
+          context.Reply(Tr(context, "command.gun.not_allowed", displayName, roundType.Value));
+          return;
+        }
+        if (IsAlreadyPreferred(_prefs.GetPistolPrimary(steamId, isCt), canonicalName))
+        {
+          context.Reply(Tr(context, "command.gun.already_set", displayName));
+          return;
+        }
+        _prefs.SetPistolPrimary(steamId, isCt, canonicalName);
+        ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
+        context.Reply(Tr(context, "command.gun.set", displayName, "Pistol"));
+        break;
+
+      case RoundType.HalfBuy:
+      case RoundType.FullBuy:
+        var roundLabel = roundType.Value == RoundType.HalfBuy ? "HalfBuy" : "FullBuy";
+        if (isPrimary && !isPistol)
+        {
+          var currentPrimary = roundType.Value == RoundType.HalfBuy
+            ? _prefs.GetHalfBuyPack(steamId, isCt).Primary
+            : _prefs.GetFullBuyPack(steamId, isCt).Primary;
+          if (IsAlreadyPreferred(currentPrimary, canonicalName))
+          {
+            context.Reply(Tr(context, "command.gun.already_set", displayName));
+            return;
+          }
+          if (roundType.Value == RoundType.HalfBuy)
+            _prefs.SetHalfBuyPrimary(steamId, isCt, canonicalName);
+          else
+            _prefs.SetFullBuyPrimary(steamId, isCt, canonicalName);
+          ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: false);
+          context.Reply(Tr(context, "command.gun.set_primary", displayName, roundLabel));
+        }
+        else if (isPistol)
+        {
+          var currentSecondary = roundType.Value == RoundType.HalfBuy
+            ? _prefs.GetHalfBuyPack(steamId, isCt).Secondary
+            : _prefs.GetFullBuyPack(steamId, isCt).Secondary;
+          if (IsAlreadyPreferred(currentSecondary, canonicalName))
+          {
+            context.Reply(Tr(context, "command.gun.already_set", displayName));
+            return;
+          }
+          if (roundType.Value == RoundType.HalfBuy)
+            _prefs.SetHalfBuySecondary(steamId, isCt, canonicalName);
+          else
+            _prefs.SetFullBuySecondary(steamId, isCt, canonicalName);
+          ReplaceWeaponInSlot(player, canonicalName, isPistolSlot: true);
+          context.Reply(Tr(context, "command.gun.set_secondary", displayName, roundLabel));
+        }
+        else
+        {
+          context.Reply(Tr(context, "command.gun.not_allowed", displayName, roundType.Value));
+        }
+        break;
+    }
+  }
+
+  private static bool IsAlreadyPreferred(string? current, string desired)
+  {
+    return !string.IsNullOrWhiteSpace(current) && current.Equals(desired, StringComparison.OrdinalIgnoreCase);
+  }
+
+  private static void ReplaceWeaponInSlot(IPlayer player, string weaponName, bool isPistolSlot)
+  {
+    var pawn = player.PlayerPawn;
+    if (pawn is null) return;
+
+    var weaponServices = pawn.WeaponServices;
+    var itemServices = pawn.ItemServices;
+    if (weaponServices is null || itemServices is null) return;
+
+    var slot = isPistolSlot ? gear_slot_t.GEAR_SLOT_PISTOL : gear_slot_t.GEAR_SLOT_RIFLE;
+    weaponServices.RemoveWeaponBySlot(slot);
+    itemServices.GiveItem(weaponName);
   }
 
   private void Awp(ICommandContext context)

--- a/src/Handlers/PlayerEventHandlers.cs
+++ b/src/Handlers/PlayerEventHandlers.cs
@@ -102,7 +102,22 @@ public sealed class PlayerEventHandlers
       return HookResult.Continue;
     }
 
-    // Block team switching for players already on T/CT outside warmup
+    // Allow switching to spectator (jointeam 1 or spectate command)
+    if (cmd.StartsWith("spectate"))
+    {
+      return HookResult.Continue;
+    }
+
+    if (cmd.StartsWith("jointeam"))
+    {
+      var parts = cmd.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+      if (parts.Length >= 2 && parts[1] == "1")
+      {
+        return HookResult.Continue;
+      }
+    }
+
+    // Block T/CT switching for players already on T/CT outside warmup
     return HookResult.Stop;
   }
 
@@ -180,12 +195,13 @@ public sealed class PlayerEventHandlers
     }
 
     // Prevent manual team switching mid-round: keep participants on their locked team.
+    // Allow switching to spectator (voluntary spec).
     if (isHuman && _state.RoundLive && _state.TryGetLockedTeam(player.SteamID, out var lockedTeam))
     {
       var currentTeam = (Team)player.Controller.TeamNum;
       if (lockedTeam == Team.T || lockedTeam == Team.CT)
       {
-        if (currentTeam != lockedTeam)
+        if (currentTeam != lockedTeam && currentTeam != Team.Spectator && currentTeam != Team.None)
         {
           core?.Scheduler.NextTick(() =>
           {
@@ -193,7 +209,8 @@ public sealed class PlayerEventHandlers
             if (!_state.RoundLive) return;
             if (!_state.TryGetLockedTeam(player.SteamID, out var stillLocked)) return;
             if (stillLocked != Team.T && stillLocked != Team.CT) return;
-            if ((Team)player.Controller.TeamNum == stillLocked) return;
+            var teamNow = (Team)player.Controller.TeamNum;
+            if (teamNow == stillLocked || teamNow == Team.Spectator || teamNow == Team.None) return;
             player.ChangeTeam(stillLocked);
           });
         }

--- a/src/Handlers/PlayerEventHandlers.cs
+++ b/src/Handlers/PlayerEventHandlers.cs
@@ -27,6 +27,7 @@ public sealed class PlayerEventHandlers
   private Guid _playerDisconnectHook;
   private Guid _clientCommandHook;
   private Guid _playerHurtHook;
+  private Guid _bombDefusedHook;
 
   public PlayerEventHandlers(IPawnLifecycleService pawnLifecycle, IClutchAnnounceService clutch, IPlayerPreferencesService prefs, IRetakesStateService state, IRetakesConfigService config, IQueueService queue, IDamageReportService damageReport, ISoloBotService soloBot)
   {
@@ -49,6 +50,7 @@ public sealed class PlayerEventHandlers
     _playerDeathHook = core.GameEvent.HookPost<EventPlayerDeath>(OnPlayerDeath);
     _playerDisconnectHook = core.GameEvent.HookPost<EventPlayerDisconnect>(OnPlayerDisconnect);
     _playerHurtHook = core.GameEvent.HookPost<EventPlayerHurt>(OnPlayerHurt);
+    _bombDefusedHook = core.GameEvent.HookPost<EventBombDefused>(OnBombDefused);
     _clientCommandHook = core.Command.HookClientCommand(OnClientCommand);
   }
 
@@ -60,6 +62,7 @@ public sealed class PlayerEventHandlers
     if (_playerDeathHook != Guid.Empty) core.GameEvent.Unhook(_playerDeathHook);
     if (_playerDisconnectHook != Guid.Empty) core.GameEvent.Unhook(_playerDisconnectHook);
     if (_playerHurtHook != Guid.Empty) core.GameEvent.Unhook(_playerHurtHook);
+    if (_bombDefusedHook != Guid.Empty) core.GameEvent.Unhook(_bombDefusedHook);
     if (_clientCommandHook != Guid.Empty) core.Command.UnhookClientCommand(_clientCommandHook);
     _playerSpawnPreHook = Guid.Empty;
     _playerSpawnPostHook = Guid.Empty;
@@ -67,6 +70,7 @@ public sealed class PlayerEventHandlers
     _playerDeathHook = Guid.Empty;
     _playerDisconnectHook = Guid.Empty;
     _playerHurtHook = Guid.Empty;
+    _bombDefusedHook = Guid.Empty;
     _clientCommandHook = Guid.Empty;
     _core = null;
   }
@@ -254,7 +258,33 @@ public sealed class PlayerEventHandlers
 
   private HookResult OnPlayerDeath(EventPlayerDeath @event)
   {
+    var core = _core;
+    if (core is not null)
+    {
+      var attackerId = @event.Attacker;
+      if (attackerId > 0)
+      {
+        var attacker = core.PlayerManager.GetAllPlayers()
+          .FirstOrDefault(p => p.IsValid && (p.PlayerID == attackerId || p.Slot == attackerId));
+        if (attacker is not null)
+        {
+          _damageReport.OnPlayerKill(attacker);
+        }
+      }
+    }
+
     _clutch.OnPlayerCountMayHaveChanged();
+    return HookResult.Continue;
+  }
+
+  private HookResult OnBombDefused(EventBombDefused @event)
+  {
+    var defuser = @event.UserIdPlayer;
+    if (defuser is not null && defuser.IsValid && defuser.SteamID != 0)
+    {
+      _damageReport.SetLastDefuser(defuser.SteamID);
+    }
+
     return HookResult.Continue;
   }
 

--- a/src/Handlers/RoundEventHandlers.cs
+++ b/src/Handlers/RoundEventHandlers.cs
@@ -319,9 +319,8 @@ public sealed class RoundEventHandlers
     var enabled = _teamBalanceEnabled;
     var ratioVar = _teamBalanceTerroristRatio;
     var forceEven = _teamBalanceForceEvenOn10;
-    var skillEnabled = _teamBalanceSkillEnabled;
     var includeBots = _teamBalanceIncludeBots;
-    if (enabled is null || ratioVar is null || forceEven is null || skillEnabled is null || includeBots is null) return;
+    if (enabled is null || ratioVar is null || forceEven is null || includeBots is null) return;
     if (!enabled.Value) return;
 
     var rules = core.EntitySystem?.GetGameRules();
@@ -332,7 +331,7 @@ public sealed class RoundEventHandlers
       .Where(p => (Team)p.Controller.TeamNum == Team.T || (Team)p.Controller.TeamNum == Team.CT)
       .ToList();
 
-    var balancePlayers = includeBots.Value
+    var balancePlayers = (includeBots?.Value ?? false)
       ? players
       : players.Where(PlayerUtil.IsHuman).ToList();
 
@@ -346,132 +345,37 @@ public sealed class RoundEventHandlers
     targetT = Math.Clamp(targetT, 1, total - 1);
 
     var currentT = balancePlayers.Count(p => (Team)p.Controller.TeamNum == Team.T);
+    var lastWinner = _state.LastWinner;
 
-    if (skillEnabled.Value)
+    // T won: keep teams as-is, only fix count mismatches from joins/leaves.
+    if (lastWinner == Team.T)
     {
-      var desiredT = targetT;
-      var desiredCT = total - targetT;
+      FixTeamCounts(balancePlayers, currentT, targetT);
+      return;
+    }
 
-      if (currentT == desiredT)
-      {
-        if (desiredT == desiredCT) return;
+    // CT won: defuser and top killers get priority for T (attacker) side.
+    if (lastWinner == Team.CT)
+    {
+      var defuserSteamId = _damageReport.GetLastDefuser();
 
-        var lastWinner = _state.LastWinner;
-        if (lastWinner != Team.T && lastWinner != Team.CT) return;
-
-        var otherTeam = lastWinner == Team.T ? Team.CT : Team.T;
-
-        var lastWinnerPlayers = balancePlayers.Where(p => (Team)p.Controller.TeamNum == lastWinner).ToList();
-        var otherPlayers = balancePlayers.Where(p => (Team)p.Controller.TeamNum == otherTeam).ToList();
-
-        if (lastWinnerPlayers.Count <= otherPlayers.Count) return;
-        if (lastWinnerPlayers.Count == 0 || otherPlayers.Count == 0) return;
-
-        var bestWinner = lastWinnerPlayers
-          .Select(p => (Player: p, Score: _damageReport.GetPlayerScore(p)))
-          .OrderByDescending(x => x.Score)
-          .ThenBy(x => x.Player.Slot)
-          .Select(x => x.Player)
-          .FirstOrDefault();
-
-        var worstOther = otherPlayers
-          .Select(p => (Player: p, Score: _damageReport.GetPlayerScore(p)))
-          .OrderBy(x => x.Score)
-          .ThenBy(x => x.Player.Slot)
-          .Select(x => x.Player)
-          .FirstOrDefault();
-
-        if (bestWinner is null || worstOther is null) return;
-
-        _state.BeginTeamChangeBypass();
-        try
-        {
-          bestWinner.ChangeTeam(otherTeam);
-          worstOther.ChangeTeam(lastWinner);
-        }
-        finally
-        {
-          _state.EndTeamChangeBypass();
-        }
-
-        return;
-      }
-
-      var scored = balancePlayers
-        .Select(p => (Player: p, Score: _damageReport.GetPlayerScore(p)))
-        .OrderByDescending(x => x.Score)
+      // Rank all players: defuser first, then by round kills desc, then by cumulative score desc.
+      var ranked = balancePlayers
+        .Select(p => (
+          Player: p,
+          IsDefuser: p.SteamID != 0 && p.SteamID == defuserSteamId,
+          RoundKills: _damageReport.GetRoundKills(p.SteamID),
+          RoundDamage: _damageReport.GetRoundDamage(p.SteamID)
+        ))
+        .OrderByDescending(x => x.IsDefuser)
+        .ThenByDescending(x => x.RoundKills)
+        .ThenByDescending(x => x.RoundDamage)
         .ThenBy(x => x.Player.Slot)
+        .Select(x => x.Player)
         .ToList();
 
-      var newT = new System.Collections.Generic.List<IPlayer>(desiredT);
-      var newCT = new System.Collections.Generic.List<IPlayer>(desiredCT);
-      float sumT = 0f;
-      float sumCT = 0f;
-
-      foreach (var (player, score) in scored)
-      {
-        if (newT.Count >= desiredT)
-        {
-          newCT.Add(player);
-          sumCT += score;
-          continue;
-        }
-
-        if (newCT.Count >= desiredCT)
-        {
-          newT.Add(player);
-          sumT += score;
-          continue;
-        }
-
-        var avgT = newT.Count == 0 ? 0f : (sumT / newT.Count);
-        var avgCT = newCT.Count == 0 ? 0f : (sumCT / newCT.Count);
-
-        if (avgT < avgCT)
-        {
-          newT.Add(player);
-          sumT += score;
-        }
-        else if (avgCT < avgT)
-        {
-          newCT.Add(player);
-          sumCT += score;
-        }
-        else
-        {
-          // In uneven setups (e.g. 1v2), always prefer the smaller side on ties
-          // so the top-scoring player doesn't end up on the larger team.
-          if (desiredT < desiredCT)
-          {
-            newT.Add(player);
-            sumT += score;
-          }
-          else if (desiredCT < desiredT)
-          {
-            newCT.Add(player);
-            sumCT += score;
-          }
-          else
-          {
-            var lastWinner = _state.LastWinner;
-            if (lastWinner == Team.T && newCT.Count < desiredCT)
-            {
-              newCT.Add(player);
-              sumCT += score;
-            }
-            else if (lastWinner == Team.CT && newT.Count < desiredT)
-            {
-              newT.Add(player);
-              sumT += score;
-            }
-            else
-            {
-              newCT.Add(player);
-              sumCT += score;
-            }
-          }
-        }
-      }
+      var newT = ranked.Take(targetT).ToList();
+      var newCT = ranked.Skip(targetT).ToList();
 
       _state.BeginTeamChangeBypass();
       try
@@ -494,6 +398,12 @@ public sealed class RoundEventHandlers
       return;
     }
 
+    // No winner yet (first round / draw): fix counts only.
+    FixTeamCounts(balancePlayers, currentT, targetT);
+  }
+
+  private void FixTeamCounts(System.Collections.Generic.List<IPlayer> balancePlayers, int currentT, int targetT)
+  {
     if (currentT == targetT) return;
 
     if (currentT > targetT)
@@ -505,17 +415,14 @@ public sealed class RoundEventHandlers
         .Take(moveCount)
         .ToList();
 
-      foreach (var p in candidates)
+      _state.BeginTeamChangeBypass();
+      try
       {
-        _state.BeginTeamChangeBypass();
-        try
-        {
-          p.ChangeTeam(Team.CT);
-        }
-        finally
-        {
-          _state.EndTeamChangeBypass();
-        }
+        foreach (var p in candidates) p.ChangeTeam(Team.CT);
+      }
+      finally
+      {
+        _state.EndTeamChangeBypass();
       }
     }
     else
@@ -527,17 +434,14 @@ public sealed class RoundEventHandlers
         .Take(moveCount)
         .ToList();
 
-      foreach (var p in candidates)
+      _state.BeginTeamChangeBypass();
+      try
       {
-        _state.BeginTeamChangeBypass();
-        try
-        {
-          p.ChangeTeam(Team.T);
-        }
-        finally
-        {
-          _state.EndTeamChangeBypass();
-        }
+        foreach (var p in candidates) p.ChangeTeam(Team.T);
+      }
+      finally
+      {
+        _state.EndTeamChangeBypass();
       }
     }
   }

--- a/src/Handlers/RoundEventHandlers.cs
+++ b/src/Handlers/RoundEventHandlers.cs
@@ -218,7 +218,7 @@ public sealed class RoundEventHandlers
     var core = _core;
     if (core is null) return;
 
-    var rules = core.EntitySystem.GetGameRules();
+    var rules = core.EntitySystem?.GetGameRules();
     if (rules is not null && rules.WarmupPeriod) return;
 
     var cfg = _config.Config.TeamBalance;
@@ -324,7 +324,7 @@ public sealed class RoundEventHandlers
     if (enabled is null || ratioVar is null || forceEven is null || skillEnabled is null || includeBots is null) return;
     if (!enabled.Value) return;
 
-    var rules = core.EntitySystem.GetGameRules();
+    var rules = core.EntitySystem?.GetGameRules();
     if (rules is not null && rules.WarmupPeriod) return;
 
     var players = core.PlayerManager.GetAllPlayers()
@@ -550,7 +550,7 @@ public sealed class RoundEventHandlers
     var core = _core;
     if (core is not null)
     {
-      var rules = core.EntitySystem.GetGameRules();
+      var rules = core.EntitySystem?.GetGameRules();
       isWarmup = rules is not null && rules.WarmupPeriod;
     }
 

--- a/src/Interfaces/IAllocationService.cs
+++ b/src/Interfaces/IAllocationService.cs
@@ -13,6 +13,11 @@ public interface IAllocationService
   RoundType? CurrentRoundType { get; }
 
   /// <summary>
+  /// Whether instant weapon swap on preference change is enabled.
+  /// </summary>
+  bool InstantSwapEnabled { get; }
+
+  /// <summary>
   /// Selects the round type for the current round.
   /// </summary>
   /// <returns>The selected round type</returns>

--- a/src/Interfaces/IDamageReportService.cs
+++ b/src/Interfaces/IDamageReportService.cs
@@ -14,5 +14,15 @@ public interface IDamageReportService
 
   float GetPlayerScore(IPlayer player);
 
+  void OnPlayerKill(IPlayer attacker);
+
+  int GetRoundKills(ulong steamId);
+
+  int GetRoundDamage(ulong steamId);
+
+  void SetLastDefuser(ulong steamId);
+
+  ulong GetLastDefuser();
+
   void PrintRoundReport();
 }

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -11,7 +11,7 @@ using SwiftlyS2_Retakes.Logging;
 
 namespace SwiftlyS2_Retakes;
 
-[PluginMetadata(Id = "Retakes", Version = "1.1.7", Name = "Retakes", Author = "aga", Description = "No description.")]
+[PluginMetadata(Id = "Retakes", Version = "1.2.0", Name = "Retakes", Author = "aga", Description = "No description.")]
 
 public partial class SwiftlyS2_Retakes : BasePlugin
 {

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -123,7 +123,7 @@ public partial class SwiftlyS2_Retakes : BasePlugin
       _pawnLifecycle, _clutch, _prefs, _state, _config, _queue, _damageReport, _soloBot);
 
     _commandHandlers = new CommandHandlers(
-      _mapConfig, _spawnManager, _pawnLifecycle, _spawnViz, _state, _prefs, _config, _smokeScenario);
+      _mapConfig, _spawnManager, _pawnLifecycle, _spawnViz, _state, _prefs, _config, _smokeScenario, _allocation);
 
     _mapEventHandlers = new MapEventHandlers(mapName =>
     {

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -110,7 +110,10 @@ public sealed class AllocationService : IAllocationService
     var sequence = _config.Config.Allocation.RoundTypeSequence;
     if (sequence is not { Count: > 0 }) return RoundType.FullBuy;
 
-    var roundNumber = Math.Max(1, _state.RoundNumber);
+    // Use actual game scores instead of internal counter — scores reflect completed rounds,
+    // so current round = completed + 1. This stays accurate after mp_restartgame resets.
+    var matchData = _core.Game.MatchData;
+    var roundNumber = Math.Max(1, matchData.CTScoreTotal + matchData.TerroristScoreTotal + 1);
     var cumulative = 0;
     for (var i = 0; i < sequence.Count; i++)
     {

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -19,6 +19,7 @@ public sealed class AllocationService : IAllocationService
   private readonly IRetakesConfigService _config;
 
   public RoundType? CurrentRoundType { get; private set; }
+  public bool InstantSwapEnabled => _instantSwap.Value;
 
   private bool _stripWeaponsDisabled;
 
@@ -42,6 +43,7 @@ public sealed class AllocationService : IAllocationService
   private readonly IConVar<string> _awpPriorityFlag;
   private readonly IConVar<int> _awpPriorityPct;
 
+  private readonly IConVar<bool> _instantSwap;
   private readonly IConVar<bool> _stripWeapons;
   private readonly IConVar<bool> _givePistolOnRifleRounds;
   private readonly IConVar<bool> _stripRemove;
@@ -77,6 +79,7 @@ public sealed class AllocationService : IAllocationService
     _awpPriorityFlag = core.ConVar.CreateOrFind("retakes_allocation_awp_priority_flag", "Permission flag eligible for AWP priority (empty=disabled)", "");
     _awpPriorityPct = core.ConVar.CreateOrFind("retakes_allocation_awp_priority_pct", "Chance (0-100) to pick a priority player for each AWP slot", 0, 0, 100);
 
+    _instantSwap = core.ConVar.CreateOrFind("retakes_allocation_instant_swap", "Instantly swap weapons when player changes preference mid-round", true);
     _stripWeapons = core.ConVar.CreateOrFind("retakes_allocation_strip_weapons", "Drop existing weapons before giving loadout (prevents duplicates)", true);
     _givePistolOnRifleRounds = core.ConVar.CreateOrFind("retakes_allocation_give_pistol_on_rifle_rounds", "Give a configured pistol on half/full buy rounds", true);
     _stripRemove = core.ConVar.CreateOrFind("retakes_allocation_strip_remove", "Remove weapons instead of dropping them (recommended; keeps ground clean)", true);

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -207,7 +207,7 @@ public sealed class AllocationService : IAllocationService
       TryStripWeapons(pawn);
     }
 
-    if (roundType == RoundType.Pistol)
+    if (roundType == RoundType.Pistol && !_config.Config.Allocation.PistolHelmet)
     {
       itemServices.GiveItem("item_kevlar");
     }

--- a/src/Services/ConVarApplicator.cs
+++ b/src/Services/ConVarApplicator.cs
@@ -44,6 +44,8 @@ public sealed class ConVarApplicator
     ApplyString("retakes_allocation_awp_priority_flag", config.Allocation.AwpPriorityFlag);
     ApplyInt("retakes_allocation_awp_priority_pct", config.Allocation.AwpPriorityPct);
 
+    ApplyBool("retakes_allocation_instant_swap", config.Allocation.InstantSwap);
+
     // Bomb settings
     ApplyBool("retakes_auto_plant", config.Bomb.AutoPlant);
     ApplyBool("retakes_enforce_no_c4", config.Bomb.EnforceNoC4);

--- a/src/Services/DamageReportService.cs
+++ b/src/Services/DamageReportService.cs
@@ -14,6 +14,8 @@ public sealed class DamageReportService : IDamageReportService
   private readonly IConVar<bool> _enabled;
 
   private readonly Dictionary<ulong, float> _scoreByPlayer = new();
+  private readonly Dictionary<ulong, int> _roundKills = new();
+  private ulong _lastDefuser;
   private const float ScoreDecay = 0.80f;
 
   private static ulong GetScoreKey(IPlayer player)
@@ -47,6 +49,8 @@ public sealed class DamageReportService : IDamageReportService
   public void OnRoundStart(bool isWarmup)
   {
     _byAttacker.Clear();
+    _roundKills.Clear();
+    _lastDefuser = 0;
     if (isWarmup)
     {
       _scoreByPlayer.Clear();
@@ -113,6 +117,42 @@ public sealed class DamageReportService : IDamageReportService
     var key = GetScoreKey(player);
     if (key == 0) return 0f;
     return _scoreByPlayer.TryGetValue(key, out var score) ? score : 0f;
+  }
+
+  public void OnPlayerKill(IPlayer attacker)
+  {
+    if (attacker is null || !attacker.IsValid) return;
+    var key = GetScoreKey(attacker);
+    if (key == 0) return;
+    _roundKills.TryGetValue(key, out var count);
+    _roundKills[key] = count + 1;
+  }
+
+  public int GetRoundKills(ulong steamId)
+  {
+    return _roundKills.TryGetValue(steamId, out var count) ? count : 0;
+  }
+
+  public int GetRoundDamage(ulong steamId)
+  {
+    if (steamId == 0) return 0;
+    if (!_byAttacker.TryGetValue(steamId, out var byVictim)) return 0;
+    var total = 0;
+    foreach (var (_, stats) in byVictim)
+    {
+      total += stats.Damage;
+    }
+    return total;
+  }
+
+  public void SetLastDefuser(ulong steamId)
+  {
+    _lastDefuser = steamId;
+  }
+
+  public ulong GetLastDefuser()
+  {
+    return _lastDefuser;
   }
 
   public void OnPlayerHurt(IPlayer attacker, IPlayer victim, int dmgHealth)

--- a/src/Services/RetakesCfgGenerator.cs
+++ b/src/Services/RetakesCfgGenerator.cs
@@ -39,7 +39,10 @@ public sealed class RetakesCfgGenerator
 
       if (!Directory.Exists(cfgDir)) Directory.CreateDirectory(cfgDir);
 
-      GenerateCfgFile(cfgPath, freezeTime);
+      if (!File.Exists(cfgPath))
+      {
+        GenerateCfgFile(cfgPath, freezeTime);
+      }
 
       void ExecuteConfig()
       {


### PR DESCRIPTION
### `!gun <weapon>` command
Lets players change their weapon preference directly from chat instead of navigating the guns menu. The command:
- **Resolves flexible input** — accepts `weapon_ak47`, `ak47`, `ak`, `AK-47`, `m4a1-s`, `deagle`, `usp`, etc. via an alias dictionary and normalized matching (strips hyphens/spaces)
- **Round-type aware** — checks the current round type and validates the weapon is allowed (e.g., won't let you pick a rifle during pistol rounds)
- **Auto-assigns slot** — determines whether the weapon is a primary or secondary and sets the correct preference (pistol primary, half-buy/full-buy primary or secondary)
- **Instant swap** — saves the preference *and* immediately removes the old weapon from the slot and gives the new one, no respawn needed
- **Duplicate check** — skips if the weapon is already your preferred choice

<img width="551" height="351" alt="image" src="https://github.com/user-attachments/assets/18c12b3c-9484-4e3f-bc11-17d0aaf63da9" />

### Other updates
- `PistolHelmet` config option - Enables/disables helmet on pistol rounds

### Bug fixes
- Null-safe `EntitySystem?.GetGameRules()` in `RoundEventHandlers` (3 places)
- Round type sequence now uses actual match scores instead of internal counter, fixing desync after `mp_restartgame`
- `retakes.cfg` only generated if the file doesn't exist, preserving manual server edits
- Allow players to change to Spectator team
- Teams are now properly balanced when round ends
  - If CTs win, CTs are transferred to T team with priority to the one who defused the bomb, and next priority is given by who did most damage that round
    - if Ts win, teams stay the same

