### PR TITLE
fix: Alive ghost players

### DIFF
--- a/src/Handlers/RoundEventHandlers.cs
+++ b/src/Handlers/RoundEventHandlers.cs
@@ -8,6 +8,7 @@ using SwiftlyS2_Retakes.Models;
 using SwiftlyS2_Retakes.Utils;
 using System;
 using System.Linq;
+using SwiftlyS2.Shared.GameEvents;
 
 namespace SwiftlyS2_Retakes.Handlers;
 
@@ -684,6 +685,28 @@ public sealed class RoundEventHandlers
 
     _damageReport.PrintRoundReport();
 
+    return HookResult.Continue;
+  }
+
+  [GameEventHandler(HookMode.Pre)]
+  public HookResult FixPlayerGhosts(EventRoundFreezeEnd @event)
+  {
+    var core = _core;
+    if (core is null) return HookResult.Continue;
+
+    var players = core.PlayerManager.GetAllValidPlayers().Where(p => 
+        p.IsAlive && 
+        p.PlayerPawn != null && 
+        p.PlayerPawn.Team == Team.Spectator);
+
+    foreach (var player in players)
+    {
+        if (!player.IsValid) continue;
+        if (player.PlayerPawn == null) continue;
+        
+        player.ChangeTeam(Team.None);
+        player.ChangeTeam(Team.Spectator);
+    }
     return HookResult.Continue;
   }
 }

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -11,7 +11,7 @@ using SwiftlyS2_Retakes.Logging;
 
 namespace SwiftlyS2_Retakes;
 
-[PluginMetadata(Id = "Retakes", Version = "1.4.0", Name = "Retakes", Author = "aga", Description = "No description.")]
+[PluginMetadata(Id = "Retakes", Version = "1.4.1", Name = "Retakes", Author = "aga", Description = "No description.")]
 
 public partial class SwiftlyS2_Retakes : BasePlugin
 {


### PR DESCRIPTION
Fixed a case where players in spectator team would be spawned in on the map, could knife CT/T players and pickup weapons - https://github.com/a2Labs-cc/SwiftlyS2-Retakes/issues/15