### PR TITLE
fix: Crashes when pawn is null OnPlayerHurt

### DIFF
--- a/src/Handlers/PlayerEventHandlers.cs
+++ b/src/Handlers/PlayerEventHandlers.cs
@@ -349,7 +349,12 @@ public sealed class PlayerEventHandlers
     var attacker = @event.AttackerPlayer;
     if (attacker is null || !attacker.IsValid) return HookResult.Continue;
 
-    _damageReport.OnPlayerHurt(attacker, victim, @event.DmgHealth);
+   if (attacker.Pawn is null) return HookResult.Continue;
+   if (victim.Pawn is null) return HookResult.Continue;
+
+    var damage = @event.DmgHealth;
+
+    _damageReport.OnPlayerHurt(attacker, victim, damage);
     return HookResult.Continue;
   }
 

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -11,7 +11,7 @@ using SwiftlyS2_Retakes.Logging;
 
 namespace SwiftlyS2_Retakes;
 
-[PluginMetadata(Id = "Retakes", Version = "1.4.4", Name = "Retakes", Author = "aga", Description = "No description.")]
+[PluginMetadata(Id = "Retakes", Version = "1.4.5", Name = "Retakes", Author = "aga", Description = "No description.")]
 
 public partial class SwiftlyS2_Retakes : BasePlugin
 {


### PR DESCRIPTION
Fixes random crashes on OnPlayerHurt event when attacker or victim pawn is null