### PR TITLE
fix: Added config var to disable player-side spawn menu and grenade allocation fixes

### DIFF
--- a/resources/translations/en.jsonc
+++ b/resources/translations/en.jsonc
@@ -84,6 +84,7 @@
 
   "command.spawns.enabled": "[green]Retakes:[white] Spawn Menu enabled",
   "command.spawns.disabled": "[green]Retakes:[white] Spawn Menu disabled",
+  "command.spawns.feature_disabled": "[green]Retakes:[white] Spawn Menu is disabled by the server",
 
   "command.awp.enabled": "[green]Retakes:[white] AWP preference enabled",
   "command.awp.disabled": "[green]Retakes:[white] AWP preference disabled",

--- a/resources/translations/lt.jsonc
+++ b/resources/translations/lt.jsonc
@@ -84,6 +84,7 @@
 
   "command.spawns.enabled": "[green]Retakes:[white] Spawnų meniu įjungtas",
   "command.spawns.disabled": "[green]Retakes:[white] Spawnų meniu išjungtas",
+  "command.spawns.feature_disabled": "[green]Retakes:[white] Spawnų meniu yra išjungtas serverio",
 
   "command.awp.enabled": "[green]Retakes:[white] AWP preferencija įjungta",
   "command.awp.disabled": "[green]Retakes:[white] AWP preferencija išjungta",

--- a/resources/translations/pt-BR.jsonc
+++ b/resources/translations/pt-BR.jsonc
@@ -84,6 +84,7 @@
 
   "command.spawns.enabled": "[green]Retakes:[white] Menu de Spawns ativado",
   "command.spawns.disabled": "[green]Retakes:[white] Menu de Spawns desativado",
+  "command.spawns.feature_disabled": "[green]Retakes:[white] O Menu de Spawns está desativado pelo servidor",
 
   "command.awp.enabled": "[green]Retakes:[white] preferência de AWP ativada",
   "command.awp.disabled": "[green]Retakes:[white] preferência de AWP desativada",

--- a/src/Configuration/PreferencesConfig.cs
+++ b/src/Configuration/PreferencesConfig.cs
@@ -6,5 +6,6 @@ namespace SwiftlyS2_Retakes.Configuration;
 public sealed class PreferencesConfig
 {
   public bool UsePerTeamPreferences { get; set; } = true;
+  public bool SpawnMenuEnabled { get; set; } = true;
   public string DatabaseConnectionName { get; set; } = "default";
 }

--- a/src/Handlers/CommandHandlers.cs
+++ b/src/Handlers/CommandHandlers.cs
@@ -853,6 +853,12 @@ public sealed class CommandHandlers
       return;
     }
 
+    if (!_config.Config.Preferences.SpawnMenuEnabled)
+    {
+      context.Reply(Tr(context, "command.spawns.feature_disabled"));
+      return;
+    }
+
     var enabled = _prefs.ToggleSpawnMenu(context.Sender.SteamID);
     context.Reply(enabled ? Tr(context, "command.spawns.enabled") : Tr(context, "command.spawns.disabled"));
   }
@@ -863,16 +869,19 @@ public sealed class CommandHandlers
       .Design.SetMenuTitle("Retake")
       .EnableSound();
 
-    var spawnMenuEnabled = _prefs.WantsSpawnMenu(player.SteamID);
-    var spawnMenuText = spawnMenuEnabled ? "Spawn Menu: ON" : "Spawn Menu: OFF";
-    var spawnMenuToggle = new ButtonMenuOption(spawnMenuText);
-    spawnMenuToggle.Click += async (_, args) =>
+    if (_config.Config.Preferences.SpawnMenuEnabled)
     {
-      _prefs.ToggleSpawnMenu(args.Player.SteamID);
-      OpenRetakeMenu(core, args.Player);
-      await ValueTask.CompletedTask;
-    };
-    builder.AddOption(spawnMenuToggle);
+      var spawnMenuEnabled = _prefs.WantsSpawnMenu(player.SteamID);
+      var spawnMenuText = spawnMenuEnabled ? "Spawn Menu: ON" : "Spawn Menu: OFF";
+      var spawnMenuToggle = new ButtonMenuOption(spawnMenuText);
+      spawnMenuToggle.Click += async (_, args) =>
+      {
+        _prefs.ToggleSpawnMenu(args.Player.SteamID);
+        OpenRetakeMenu(core, args.Player);
+        await ValueTask.CompletedTask;
+      };
+      builder.AddOption(spawnMenuToggle);
+    }
 
     var awpEnabled = _prefs.WantsAwp(player.SteamID);
     var awpToggleText = awpEnabled ? "Play with AWP: ON" : "Play with AWP: OFF";

--- a/src/Handlers/PlayerEventHandlers.cs
+++ b/src/Handlers/PlayerEventHandlers.cs
@@ -22,6 +22,7 @@ public sealed class PlayerEventHandlers
   private readonly IDamageReportService _damageReport;
   private readonly ISoloBotService _soloBot;
   private readonly IAllocationService _allocation;
+  private readonly ISpawnManager _spawnManager;
 
   private Guid _playerSpawnPreHook;
   private Guid _playerSpawnPostHook;
@@ -32,7 +33,7 @@ public sealed class PlayerEventHandlers
   private Guid _playerHurtHook;
   private Guid _bombDefusedHook;
 
-  public PlayerEventHandlers(IPawnLifecycleService pawnLifecycle, IClutchAnnounceService clutch, IPlayerPreferencesService prefs, IRetakesStateService state, IRetakesConfigService config, IQueueService queue, IDamageReportService damageReport, ISoloBotService soloBot, IAllocationService allocation)
+  public PlayerEventHandlers(IPawnLifecycleService pawnLifecycle, IClutchAnnounceService clutch, IPlayerPreferencesService prefs, IRetakesStateService state, IRetakesConfigService config, IQueueService queue, IDamageReportService damageReport, ISoloBotService soloBot, IAllocationService allocation, ISpawnManager spawnManager)
   {
     _pawnLifecycle = pawnLifecycle;
     _clutch = clutch;
@@ -43,6 +44,7 @@ public sealed class PlayerEventHandlers
     _damageReport = damageReport;
     _soloBot = soloBot;
     _allocation = allocation;
+    _spawnManager = spawnManager;
   }
 
   public void Register(ISwiftlyCore core)
@@ -276,6 +278,18 @@ public sealed class PlayerEventHandlers
       {
         if (spawnPlayer is null || !spawnPlayer.IsValid) return;
         _pawnLifecycle.OnPlayerSpawn(spawnPlayer);
+      });
+
+      // Apply retake spawn assignment recorded in EventRoundPrestart, after the
+      // engine has finalized default spawn placement.
+      var teleportPlayer = player;
+      core.Scheduler.NextWorldUpdate(() =>
+      {
+        if (teleportPlayer is null || !teleportPlayer.IsValid) return;
+        if (!_spawnManager.TryConsumeSpawnFor(teleportPlayer.Slot, out var spawn)) return;
+        var pawn = teleportPlayer.Pawn;
+        if (pawn is null || !pawn.IsValid) return;
+        pawn.Teleport(spawn.Position, spawn.Angle, SwiftlyS2.Shared.Natives.Vector.Zero);
       });
     }
     else

--- a/src/Handlers/RoundEventHandlers.cs
+++ b/src/Handlers/RoundEventHandlers.cs
@@ -216,10 +216,11 @@ public sealed class RoundEventHandlers
     // so the engine respects them when spawning players.
     _allocation.PreSelectRoundType();
     var core = _core;
+    var isWarmup = false;
     if (core is not null)
     {
       var rules = core.EntitySystem?.GetGameRules();
-      var isWarmup = rules is not null && rules.WarmupPeriod;
+      isWarmup = rules is not null && rules.WarmupPeriod;
       if (!isWarmup)
       {
         if (_allocation.CurrentRoundType == RoundType.Pistol && !_config.Config.Allocation.PistolHelmet)
@@ -233,6 +234,19 @@ public sealed class RoundEventHandlers
           core.Engine.ExecuteCommand("mp_max_armor 2");
         }
       }
+    }
+
+    // Select bombsite and prepare per-slot spawn assignments BEFORE the engine
+    // respawns players. Spawns are then applied from the player-spawn post hook.
+    if (!isWarmup)
+    {
+      var bombsite = _state.ForcedBombsite ?? (_random.Next(0, 2) == 0 ? Bombsite.A : Bombsite.B);
+      _currentBombsite = bombsite;
+      _spawnManager.HandleRoundSpawns(bombsite);
+    }
+    else
+    {
+      _currentBombsite = null;
     }
 
     return HookResult.Continue;
@@ -549,9 +563,13 @@ public sealed class RoundEventHandlers
       _state.SetRoundParticipants(participants);
     }
 
-    var bombsite = _state.ForcedBombsite ?? (_random.Next(0, 2) == 0 ? Bombsite.A : Bombsite.B);
-    _currentBombsite = bombsite;
-    _spawnManager.HandleRoundSpawns(bombsite);
+    var bombsite = _currentBombsite ?? _state.ForcedBombsite ?? (_random.Next(0, 2) == 0 ? Bombsite.A : Bombsite.B);
+    if (_currentBombsite is null)
+    {
+      // Fallback: prestart didn't run (e.g., warmup→live edge case). Assign now.
+      _currentBombsite = bombsite;
+      _spawnManager.HandleRoundSpawns(bombsite);
+    }
     _spawnManager.OpenCtSpawnSelectionMenu(bombsite);
     _allocation.AllocateForCurrentPlayers(_pawnLifecycle);
 

--- a/src/Interfaces/ISpawnManager.cs
+++ b/src/Interfaces/ISpawnManager.cs
@@ -35,4 +35,10 @@ public interface ISpawnManager
   /// <param name="spawn">The planter's spawn</param>
   /// <returns>True if a planter was assigned</returns>
   bool TryGetAssignedPlanter(out ulong steamId, out Spawn spawn);
+
+  /// <summary>
+  /// Consumes the pending spawn assignment for a player slot, if any.
+  /// Used by the player-spawn hook to apply retake spawns after the engine respawns players.
+  /// </summary>
+  bool TryConsumeSpawnFor(int slot, out Spawn spawn);
 }

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -11,7 +11,7 @@ using SwiftlyS2_Retakes.Logging;
 
 namespace SwiftlyS2_Retakes;
 
-[PluginMetadata(Id = "Retakes", Version = "1.4.8", Name = "Retakes", Author = "aga", Description = "No description.")]
+[PluginMetadata(Id = "Retakes", Version = "1.5.0", Name = "Retakes", Author = "aga", Description = "No description.")]
 
 public partial class SwiftlyS2_Retakes : BasePlugin
 {
@@ -123,7 +123,7 @@ public partial class SwiftlyS2_Retakes : BasePlugin
           _messages, _allocation, _autoPlant, _clutch, _damageReport, _breaker, random, _queue, _buyMenu, _smokeScenario);
 
         _playerEventHandlers = new PlayerEventHandlers(
-          _pawnLifecycle, _clutch, _prefs, _state, _config, _queue, _damageReport, _soloBot, _allocation);
+          _pawnLifecycle, _clutch, _prefs, _state, _config, _queue, _damageReport, _soloBot, _allocation, _spawnManager);
 
         _commandHandlers = new CommandHandlers(
                     _mapConfig, _spawnManager, _pawnLifecycle, _spawnViz, _state, _prefs, _config, _weaponAliasConfig, _smokeScenario, _allocation);
@@ -160,6 +160,26 @@ public partial class SwiftlyS2_Retakes : BasePlugin
         {
             _config?.ApplyToConvars(false);
         });
+
+        // On hot reload, OnMapLoad won't fire (the map is already running), so
+        // SpawnManager._spawns would stay empty and players would get default
+        // map spawns. Load the current map's config now to populate spawns.
+        if (hotReload)
+        {
+            try
+            {
+                var mapName = Core.Engine.GlobalVars.MapName.Value;
+                if (!string.IsNullOrWhiteSpace(mapName))
+                {
+                    _mapConfig.Load(mapName);
+                    _spawnManager.SetSpawns(_mapConfig.Spawns);
+                }
+            }
+            catch (Exception ex)
+            {
+                Core.Logger.LogPluginError(ex, "Retakes: failed to load map config on hot reload.");
+            }
+        }
 
         Core.Logger.LogPluginInformation("Retakes: plugin loaded successfully via DI.");
     }

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -194,32 +194,41 @@ public sealed class AllocationService : IAllocationService
     {
       pawnLifecycle.WhenPawnReady(p, _ =>
       {
-        try
+        // Defer loadout to NextWorldUpdate so it runs AFTER the spawn teleport
+        // scheduled by PlayerEventHandlers.OnPlayerSpawnPost (also NextWorldUpdate,
+        // queued earlier — FIFO guarantees teleport runs first). Otherwise items
+        // like item_defuser are created at the engine's default spawn position and
+        // get left behind when the player teleports to the retake spawn.
+        _core.Scheduler.NextWorldUpdate(() =>
         {
-          GiveLoadout(p, roundType, pistolDefuserSlot, awpReceivers, ssg08Receivers, grenadeAssignments);
-
-          // After loadout is given, schedule a delayed helmet strip for pistol rounds.
-          // The engine may re-apply helmet after our GiveItem calls, so we need to
-          // strip it on the next tick to ensure it sticks.
-          if (roundType == RoundType.Pistol && !_config.Config.Allocation.PistolHelmet)
+          if (p is null || !p.IsValid) return;
+          try
           {
-            _core.Scheduler.NextTick(() =>
+            GiveLoadout(p, roundType, pistolDefuserSlot, awpReceivers, ssg08Receivers, grenadeAssignments);
+
+            // After loadout is given, schedule a delayed helmet strip for pistol rounds.
+            // The engine may re-apply helmet after our GiveItem calls, so we need to
+            // strip it on the next tick to ensure it sticks.
+            if (roundType == RoundType.Pistol && !_config.Config.Allocation.PistolHelmet)
             {
-              if (p is null || !p.IsValid) return;
-              var pawn = p.Pawn;
-              if (pawn is null || !pawn.IsValid) return;
-              if (pawn.ItemServices is CCSPlayer_ItemServices svc && svc.HasHelmet)
+              _core.Scheduler.NextTick(() =>
               {
-                svc.HasHelmet = false;
-                svc.HasHelmetUpdated();
-              }
-            });
+                if (p is null || !p.IsValid) return;
+                var pawn = p.Pawn;
+                if (pawn is null || !pawn.IsValid) return;
+                if (pawn.ItemServices is CCSPlayer_ItemServices svc && svc.HasHelmet)
+                {
+                  svc.HasHelmet = false;
+                  svc.HasHelmetUpdated();
+                }
+              });
+            }
           }
-        }
-        catch (Exception ex)
-        {
-          _logger.LogError(ex, "Retakes: allocation failed for slot={Slot}", p.Slot);
-        }
+          catch (Exception ex)
+          {
+            _logger.LogError(ex, "Retakes: allocation failed for slot={Slot}", p.Slot);
+          }
+        });
       });
     }
   }
@@ -640,13 +649,22 @@ public sealed class AllocationService : IAllocationService
 
     if (eligible.Count == 0) return;
 
+    // Shuffle a copy of the pool so the prefix doesn't always win when MaxPerPlayer/MaxPerGrenade
+    // caps prevent the full pool from being distributed.
+    var shuffledPool = new List<string>(pool);
+    for (var i = shuffledPool.Count - 1; i > 0; i--)
+    {
+      var j = _random.Next(i + 1);
+      (shuffledPool[i], shuffledPool[j]) = (shuffledPool[j], shuffledPool[i]);
+    }
+
     // Distribute pool items round-robin across eligible players (highest priority first).
     var totalCounts = new Dictionary<ulong, int>(eligible.Count);
     // grenade type -> (steamId -> count)
     var grenadeCounts = new Dictionary<string, Dictionary<ulong, int>>(StringComparer.OrdinalIgnoreCase);
-    for (var i = 0; i < pool.Count; i++)
+    for (var i = 0; i < shuffledPool.Count; i++)
     {
-      var grenade = pool[i];
+      var grenade = shuffledPool[i];
 
       // Find the next eligible player who hasn't hit the per-player cap or the per-grenade cap.
       IPlayer? recipient = null;

--- a/src/Services/PlayerPreferencesService.cs
+++ b/src/Services/PlayerPreferencesService.cs
@@ -81,11 +81,14 @@ public sealed class PlayerPreferencesService : IPlayerPreferencesService
   }
 
   public bool WantsSpawnMenu(ulong steamId) =>
-    GetBool(steamId, KeyWantsCtSpawnMenu, false);
+    _config.Config.Preferences.SpawnMenuEnabled && GetBool(steamId, KeyWantsCtSpawnMenu, false);
 
   public bool ToggleSpawnMenu(ulong steamId)
   {
-    var val = !WantsSpawnMenu(steamId);
+    if (!_config.Config.Preferences.SpawnMenuEnabled)
+      return false;
+
+    var val = !GetBool(steamId, KeyWantsCtSpawnMenu, false);
     SetBool(steamId, KeyWantsCtSpawnMenu, val);
     return val;
   }

--- a/src/Services/SpawnManager.cs
+++ b/src/Services/SpawnManager.cs
@@ -20,6 +20,7 @@ public sealed class SpawnManager : ISpawnManager
   private readonly Dictionary<Bombsite, Dictionary<Team, List<Spawn>>> _spawns = new();
 
   private readonly Dictionary<ulong, Spawn> _lastAssignments = new();
+  private readonly Dictionary<int, Spawn> _pendingTeleportBySlot = new();
   private ulong? _assignedPlanterSteamId;
   private Spawn? _assignedPlanterSpawn;
 
@@ -51,6 +52,10 @@ public sealed class SpawnManager : ISpawnManager
     _spawns[Bombsite.A][Team.CT].Clear();
     _spawns[Bombsite.B][Team.T].Clear();
     _spawns[Bombsite.B][Team.CT].Clear();
+    _pendingTeleportBySlot.Clear();
+    _lastAssignments.Clear();
+    _assignedPlanterSteamId = null;
+    _assignedPlanterSpawn = null;
 
     var seen = new HashSet<string>(StringComparer.Ordinal);
     var removedDuplicates = 0;
@@ -106,6 +111,7 @@ public sealed class SpawnManager : ISpawnManager
   public bool HandleRoundSpawns(Bombsite bombsite)
   {
     _lastAssignments.Clear();
+    _pendingTeleportBySlot.Clear();
     _assignedPlanterSteamId = null;
     _assignedPlanterSpawn = null;
 
@@ -195,7 +201,7 @@ public sealed class SpawnManager : ISpawnManager
         _assignedPlanterSpawn = spawn;
       }
 
-      _pawnLifecycle.WhenPawnReady(player, p => p.Teleport(spawn.Position, spawn.Angle, Vector.Zero));
+      _pendingTeleportBySlot[player.Slot] = spawn;
     }
 
     for (var i = 0; i < ctPlayers.Count; i++)
@@ -210,7 +216,7 @@ public sealed class SpawnManager : ISpawnManager
           var spawn = ctSpawnPool[0];
           ctSpawnPool.RemoveAt(0);
           _lastAssignments[player.SteamID] = spawn;
-          _pawnLifecycle.WhenPawnReady(player, pawn => pawn.Teleport(spawn.Position, spawn.Angle, Vector.Zero));
+          _pendingTeleportBySlot[player.Slot] = spawn;
         }
       }
       else
@@ -218,6 +224,7 @@ public sealed class SpawnManager : ISpawnManager
         // Spawns are selected interactively each round (menu opened at round start).
         // Do not auto-teleport here.
         _lastAssignments.Remove(player.SteamID);
+        _pendingTeleportBySlot.Remove(player.Slot);
       }
     }
 
@@ -345,7 +352,7 @@ public sealed class SpawnManager : ISpawnManager
         _assignedPlanterSpawn = spawn;
       }
 
-      _pawnLifecycle.WhenPawnReady(player, p => p.Teleport(spawn.Position, spawn.Angle, Vector.Zero));
+      _pendingTeleportBySlot[player.Slot] = spawn;
     }
   }
 
@@ -359,6 +366,19 @@ public sealed class SpawnManager : ISpawnManager
     }
 
     steamId = 0;
+    spawn = null!;
+    return false;
+  }
+
+  public bool TryConsumeSpawnFor(int slot, out Spawn spawn)
+  {
+    if (_pendingTeleportBySlot.TryGetValue(slot, out var s))
+    {
+      _pendingTeleportBySlot.Remove(slot);
+      spawn = s;
+      return true;
+    }
+
     spawn = null!;
     return false;
   }


### PR DESCRIPTION
- Added config var to disable player-side spawn menu
- Fixed grenade allocation to shuffle grenades per team on round start so CTs and Ts get different grenades