### PR TITLE
fix: Awp and SSG08 preference and allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The plugin saves player preferences using the [Cookies](https://github.com/Swift
 
 | Category | Preferences |
 | :--- | :--- |
-| **Weapons** | AWP toggle, SSG08 toggle, AWP priority, pistol round primary, half-buy primary/secondary, full-buy primary/secondary |
+| **Weapons** | AWP toggle, SSG08 toggle (full-buy), SSG08 half-buy toggle, AWP priority, pistol round primary, half-buy primary/secondary, full-buy primary/secondary |
 | **Spawns** | Spawn menu toggle, T/CT preferred spawn per bombsite (A and B) |
 
 ### Configuration
@@ -104,7 +104,7 @@ The plugin saves player preferences using the [Cookies](https://github.com/Swift
 | Round Type | Armor | Primary | Secondary | CT Defuser |
 | :--- | :--- | :--- | :--- | :--- |
 | **Pistol** | Kevlar only (no helmet by default) | Pistol | ❌ | 1 random CT player |
-| **Half-Buy** | Kevlar + Helmet | SMGs / budget rifles | ✅ Pistol | All CTs |
+| **Half-Buy** | Kevlar + Helmet | SMGs / budget rifles (or Scout) | ✅ Pistol | All CTs |
 | **Full-Buy** | Kevlar + Helmet | Rifles (or AWP / Scout) | ✅ Pistol | All CTs |
 
 ### Round Type Selection
@@ -217,6 +217,18 @@ Only on full-buy rounds. Players who receive an AWP are excluded.
 | `Allocation.Ssg08Enabled` | `true` | Enable SSG08 allocation |
 | `Allocation.Ssg08PerTeam` | `0` | Maximum SSG08s given per team (0 = disabled) |
 | `Allocation.Ssg08AllowEveryone` | `false` | Ignore player preference — everyone is eligible |
+
+### Scout (SSG08) Half-Buy Allocation
+
+Half-buy rounds only. Independent of the full-buy SSG08 preference — players toggle it separately in the `!retake` menu ("Play with SSG08 on half-buy"). Disabled by default; opt in by raising `Ssg08HalfPerTeam`.
+
+| Field | Default | Description |
+| :--- | :--- | :--- |
+| `Allocation.Ssg08HalfEnabled` | `true` | Enable SSG08 allocation on half-buy rounds |
+| `Allocation.Ssg08HalfPerTeam` | `0` | Maximum SSG08s given per team on half-buy (0 = disabled) |
+| `Allocation.Ssg08HalfAllowEveryone` | `false` | Ignore player preference — everyone is eligible |
+
+> `!scout` / `!ssg` / `!ssg08` toggle the SSG08 preference for **both** full-buy and half-buy at once (single switch, mirrors `!awp`). Use the `!retake` menu for per-round-type control.
 
 ### Weapon Stripping
 

--- a/resources/translations/en.jsonc
+++ b/resources/translations/en.jsonc
@@ -89,6 +89,9 @@
   "command.awp.enabled": "[green]Retakes:[white] AWP preference enabled",
   "command.awp.disabled": "[green]Retakes:[white] AWP preference disabled",
 
+  "command.ssg08.enabled": "[green]Retakes:[white] SSG08 preference enabled",
+  "command.ssg08.disabled": "[green]Retakes:[white] SSG08 preference disabled",
+
   "command.gun.usage": "[green]Retakes:[white] Usage: !gun <weapon_name>",
   "command.gun.no_round": "[green]Retakes:[white] No round in progress.",
   "command.gun.not_allowed": "[green]Retakes:[white] {0} is not allowed during {1} rounds.",

--- a/resources/translations/lt.jsonc
+++ b/resources/translations/lt.jsonc
@@ -89,6 +89,9 @@
   "command.awp.enabled": "[green]Retakes:[white] AWP preferencija įjungta",
   "command.awp.disabled": "[green]Retakes:[white] AWP preferencija išjungta",
 
+  "command.ssg08.enabled": "[green]Retakes:[white] SSG08 preferencija įjungta",
+  "command.ssg08.disabled": "[green]Retakes:[white] SSG08 preferencija išjungta",
+
   "command.gun.usage": "[green]Retakes:[white] Naudojimas: !gun <ginklo_pavadinimas>",
   "command.gun.no_round": "[green]Retakes:[white] Nėra aktyvaus raundo.",
   "command.gun.not_allowed": "[green]Retakes:[white] {0} neleidžiamas {1} raunduose.",

--- a/resources/translations/pt-BR.jsonc
+++ b/resources/translations/pt-BR.jsonc
@@ -89,6 +89,9 @@
   "command.awp.enabled": "[green]Retakes:[white] preferência de AWP ativada",
   "command.awp.disabled": "[green]Retakes:[white] preferência de AWP desativada",
 
+  "command.ssg08.enabled": "[green]Retakes:[white] preferência de SSG08 ativada",
+  "command.ssg08.disabled": "[green]Retakes:[white] preferência de SSG08 desativada",
+
   "command.gun.usage": "[green]Retakes:[white] Use: !gun <nome_da_arma>",
   "command.gun.no_round": "[green]Retakes:[white] Nenhum round em andamento.",
   "command.gun.not_allowed": "[green]Retakes:[white] {0} não é permitido durante rounds {1}.",

--- a/src/Configuration/AllocationConfig.cs
+++ b/src/Configuration/AllocationConfig.cs
@@ -25,6 +25,10 @@ public sealed class AllocationConfig
   public int Ssg08PerTeam { get; set; } = 0;
   public bool Ssg08AllowEveryone { get; set; } = false;
 
+  public bool Ssg08HalfEnabled { get; set; } = true;
+  public int Ssg08HalfPerTeam { get; set; } = 0;
+  public bool Ssg08HalfAllowEveryone { get; set; } = false;
+
   public string AwpPriorityFlag { get; set; } = "";
   public int AwpPriorityPct { get; set; } = 0;
 

--- a/src/Handlers/CommandHandlers.cs
+++ b/src/Handlers/CommandHandlers.cs
@@ -93,7 +93,12 @@ public sealed class CommandHandlers
     _commandGuids.Add(core.Command.RegisterCommand("gun", SelectGun, registerRaw: true));
     _commandGuids.Add(core.Command.RegisterCommand("retake", Retake, registerRaw: true));
     _commandGuids.Add(core.Command.RegisterCommand("spawns", Spawns, registerRaw: true));
-    _commandGuids.Add(core.Command.RegisterCommand("awp", Awp, registerRaw: true));
+    // NOTE: `!awp` is intentionally NOT registered here — it comes from the
+    // alias loop below (guns.jsonc maps `weapon_awp` → ["awp", "sniper"]).
+    // Registering it in both places caused SwiftlyS2 to fire both handlers on
+    // one chat command, toggling the AWP preference twice (net zero, but the
+    // user saw "enabled" then "disabled" flicker). Same pattern as !scout /
+    // !ssg / !ssg08 / !sniper — they only exist in the alias loop.
     _commandGuids.Add(core.Command.RegisterCommand("reloadcfg", ReloadCfg, registerRaw: true, permission: RetakesPermissions.Root));
 
     _commandGuids.Add(core.Command.RegisterCommand("debugqueues", DebugQueues, registerRaw: true));
@@ -905,6 +910,17 @@ public sealed class CommandHandlers
     };
     builder.AddOption(ssgToggle);
 
+    var ssgHalfEnabled = _prefs.WantsSsg08HalfBuy(player.SteamID);
+    var ssgHalfToggleText = ssgHalfEnabled ? "Play with SSG08 on half-buy: ON" : "Play with SSG08 on half-buy: OFF";
+    var ssgHalfToggle = new ButtonMenuOption(ssgHalfToggleText);
+    ssgHalfToggle.Click += async (_, args) =>
+    {
+      _prefs.ToggleSsg08HalfBuy(args.Player.SteamID);
+      OpenRetakeMenu(core, args.Player);
+      await ValueTask.CompletedTask;
+    };
+    builder.AddOption(ssgHalfToggle);
+
     var requiredFlag = (_config.Config.Allocation.AwpPriorityFlag ?? string.Empty).Trim();
     var pct = Math.Clamp(_config.Config.Allocation.AwpPriorityPct, 0, 100);
     if (!string.IsNullOrWhiteSpace(requiredFlag) && pct > 0)
@@ -1336,8 +1352,10 @@ public sealed class CommandHandlers
     ["ak"] = "weapon_ak47",
     ["glock"] = "weapon_glock",
     ["awp"] = "weapon_awp",
+    ["sniper"] = "weapon_awp",
     ["scout"] = "weapon_ssg08",
     ["ssg"] = "weapon_ssg08",
+    ["ssg08"] = "weapon_ssg08",
     ["galil"] = "weapon_galilar",
     ["famas"] = "weapon_famas",
     ["aug"] = "weapon_aug",
@@ -1376,6 +1394,15 @@ public sealed class CommandHandlers
       return;
     }
 
+    var weaponName = ResolveWeaponName(alias);
+
+    // Preference-toggle aliases (!awp / !sniper / !scout / !ssg / !ssg08) always
+    // set the persistent preference, regardless of whether a round is in progress
+    // and regardless of whether the weapon is in the current round's allowed
+    // primaries list. Handle them BEFORE the roundType check so the toggle also
+    // works between rounds (matching the dedicated Awp handler).
+    if (TryHandlePreferenceAlias(context, weaponName)) return;
+
     var roundType = _allocation.CurrentRoundType;
     if (roundType is null)
     {
@@ -1383,7 +1410,6 @@ public sealed class CommandHandlers
       return;
     }
 
-    var weaponName = ResolveWeaponName(alias);
     HandleGunSelection(context, roundType.Value, weaponName);
   }
 
@@ -1401,6 +1427,13 @@ public sealed class CommandHandlers
       return;
     }
 
+    var input = context.Args[0].Trim();
+    var weaponName = ResolveWeaponName(input);
+
+    // See note in SelectGunByAlias: `!gun awp` / `!gun scout` etc. also route
+    // to the preference toggle before any round-scoped allowed-primaries check.
+    if (TryHandlePreferenceAlias(context, weaponName)) return;
+
     var roundType = _allocation.CurrentRoundType;
     if (roundType is null)
     {
@@ -1408,15 +1441,51 @@ public sealed class CommandHandlers
       return;
     }
 
-    var input = context.Args[0].Trim();
-    var weaponName = ResolveWeaponName(input);
     HandleGunSelection(context, roundType.Value, weaponName);
+  }
+
+  private bool TryHandlePreferenceAlias(ICommandContext context, string weaponName)
+  {
+    var player = context.Sender;
+    if (player is null) return false;
+
+    if (weaponName.Equals("weapon_awp", StringComparison.OrdinalIgnoreCase))
+    {
+      var enabled = _prefs.ToggleAwp(player.SteamID);
+      context.Reply(enabled ? Tr(context, "command.awp.enabled") : Tr(context, "command.awp.disabled"));
+      return true;
+    }
+
+    if (weaponName.Equals("weapon_ssg08", StringComparison.OrdinalIgnoreCase))
+    {
+      // Single logical "scout preference" — the two cookies gate FullBuy and
+      // HalfBuy allocation independently, but from the chat-command surface we
+      // treat them as one switch to mirror `!awp`. If either is on, turn both
+      // off; otherwise turn both on. Precise per-round-type control is still
+      // available in the `!retake` menu.
+      var currentlyOn = _prefs.WantsSsg08(player.SteamID) || _prefs.WantsSsg08HalfBuy(player.SteamID);
+      var target = !currentlyOn;
+      if (_prefs.WantsSsg08(player.SteamID) != target) _prefs.ToggleSsg08(player.SteamID);
+      if (_prefs.WantsSsg08HalfBuy(player.SteamID) != target) _prefs.ToggleSsg08HalfBuy(player.SteamID);
+      context.Reply(target ? Tr(context, "command.ssg08.enabled") : Tr(context, "command.ssg08.disabled"));
+      return true;
+    }
+
+    return false;
   }
 
   private void HandleGunSelection(ICommandContext context, RoundType roundType, string weaponName)
   {
     var player = context.Sender;
     if (player is null) return;
+
+    // Defense-in-depth: weapon_awp / weapon_ssg08 are governed by dedicated
+    // preference toggles (WantsAwp / WantsSsg08) and MUST NEVER fall through
+    // to SetFullBuyPrimary / SetHalfBuyPrimary / ReplaceWeaponInSlot below.
+    // Every current caller already gates via TryHandlePreferenceAlias, but
+    // this guarantees the invariant even if a future entry point forgets to.
+    if (TryHandlePreferenceAlias(context, weaponName)) return;
+
     var isCt = (Team)player.Controller.TeamNum == Team.CT;
     var weapons = _config.Config.Weapons;
     var pistols = weapons.Pistols;
@@ -1541,18 +1610,6 @@ public sealed class CommandHandlers
     var slot = isPistolSlot ? gear_slot_t.GEAR_SLOT_PISTOL : gear_slot_t.GEAR_SLOT_RIFLE;
     await weaponServices.RemoveWeaponBySlotAsync(slot);
     await itemServices.GiveItemAsync(weaponName);
-  }
-
-  private void Awp(ICommandContext context)
-  {
-    if (!context.IsSentByPlayer || context.Sender is null)
-    {
-      context.Reply(Tr(context, "error.must_be_player"));
-      return;
-    }
-
-    var enabled = _prefs.ToggleAwp(context.Sender.SteamID);
-    context.Reply(enabled ? Tr(context, "command.awp.enabled") : Tr(context, "command.awp.disabled"));
   }
 
   private void ReloadCfg(ICommandContext context)

--- a/src/Interfaces/IPlayerPreferencesService.cs
+++ b/src/Interfaces/IPlayerPreferencesService.cs
@@ -18,6 +18,9 @@ public interface IPlayerPreferencesService
   bool WantsSsg08(ulong steamId);
   bool ToggleSsg08(ulong steamId);
 
+  bool WantsSsg08HalfBuy(ulong steamId);
+  bool ToggleSsg08HalfBuy(ulong steamId);
+
   bool WantsAwpPriority(ulong steamId);
   bool ToggleAwpPriority(ulong steamId);
 

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -9,6 +9,7 @@ public sealed class UserSettings
   public long UpdatedAt { get; set; }
   public bool WantsAwp { get; set; }
   public bool WantsSsg08 { get; set; }
+  public bool WantsSsg08HalfBuy { get; set; }
   public bool WantsAwpPriority { get; set; }
   public bool WantsCtSpawnMenu { get; set; }
 
@@ -38,6 +39,7 @@ public sealed class UserSettings
     UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
     WantsAwp = false,
     WantsSsg08 = false,
+    WantsSsg08HalfBuy = false,
     WantsAwpPriority = false,
     WantsCtSpawnMenu = false,
   };

--- a/src/Retakes.cs
+++ b/src/Retakes.cs
@@ -11,7 +11,7 @@ using SwiftlyS2_Retakes.Logging;
 
 namespace SwiftlyS2_Retakes;
 
-[PluginMetadata(Id = "Retakes", Version = "1.5.1", Name = "Retakes", Author = "aga", Description = "No description.")]
+[PluginMetadata(Id = "Retakes", Version = "1.5.2", Name = "Retakes", Author = "aga", Description = "No description.")]
 
 public partial class SwiftlyS2_Retakes : BasePlugin
 {

--- a/src/Services/AllocationService.cs
+++ b/src/Services/AllocationService.cs
@@ -40,6 +40,10 @@ public sealed class AllocationService : IAllocationService
   private readonly IConVar<int> _ssg08PerTeam;
   private readonly IConVar<bool> _ssg08AllowEveryone;
 
+  private readonly IConVar<bool> _ssg08HalfEnabled;
+  private readonly IConVar<int> _ssg08HalfPerTeam;
+  private readonly IConVar<bool> _ssg08HalfAllowEveryone;
+
   private readonly IConVar<string> _awpPriorityFlag;
   private readonly IConVar<int> _awpPriorityPct;
 
@@ -77,6 +81,10 @@ public sealed class AllocationService : IAllocationService
     _ssg08Enabled = core.ConVar.CreateOrFind("retakes_allocation_ssg08_enabled", "Enable SSG08 preference allocation on FullBuy", true);
     _ssg08PerTeam = core.ConVar.CreateOrFind("retakes_allocation_ssg08_per_team", "Number of SSG08s per team on FullBuy", 0, 0, 5);
     _ssg08AllowEveryone = core.ConVar.CreateOrFind("retakes_allocation_ssg08_allow_everyone", "Ignore player preference and allow everyone to receive SSG08", false);
+
+    _ssg08HalfEnabled = core.ConVar.CreateOrFind("retakes_allocation_ssg08_half_enabled", "Enable SSG08 preference allocation on HalfBuy", true);
+    _ssg08HalfPerTeam = core.ConVar.CreateOrFind("retakes_allocation_ssg08_half_per_team", "Number of SSG08s per team on HalfBuy", 0, 0, 5);
+    _ssg08HalfAllowEveryone = core.ConVar.CreateOrFind("retakes_allocation_ssg08_half_allow_everyone", "Ignore player preference and allow everyone to receive SSG08 on HalfBuy", false);
 
     _awpPriorityFlag = core.ConVar.CreateOrFind("retakes_allocation_awp_priority_flag", "Permission flag eligible for AWP priority (empty=disabled)", "");
     _awpPriorityPct = core.ConVar.CreateOrFind("retakes_allocation_awp_priority_pct", "Chance (0-100) to pick a priority player for each AWP slot", 0, 0, 100);
@@ -175,6 +183,12 @@ public sealed class AllocationService : IAllocationService
     {
       foreach (var steamId in PickSsg08Receivers(ct.Where(PlayerUtil.IsHuman).ToList(), awpReceivers)) ssg08Receivers.Add(steamId);
       foreach (var steamId in PickSsg08Receivers(t.Where(PlayerUtil.IsHuman).ToList(), awpReceivers)) ssg08Receivers.Add(steamId);
+    }
+
+    if (roundType == RoundType.HalfBuy && _ssg08HalfEnabled.Value)
+    {
+      foreach (var steamId in PickSsg08HalfBuyReceivers(ct.Where(PlayerUtil.IsHuman).ToList())) ssg08Receivers.Add(steamId);
+      foreach (var steamId in PickSsg08HalfBuyReceivers(t.Where(PlayerUtil.IsHuman).ToList())) ssg08Receivers.Add(steamId);
     }
 
     var pistolDefuserSlot = -1;
@@ -279,6 +293,10 @@ public sealed class AllocationService : IAllocationService
       primary = "weapon_awp";
     }
     else if (roundType == RoundType.FullBuy && ssg08Receivers.Contains(player.SteamID))
+    {
+      primary = "weapon_ssg08";
+    }
+    else if (roundType == RoundType.HalfBuy && ssg08Receivers.Contains(player.SteamID))
     {
       primary = "weapon_ssg08";
     }
@@ -553,6 +571,32 @@ public sealed class AllocationService : IAllocationService
     var candidates = _ssg08AllowEveryone.Value
       ? basePool
       : basePool.Where(p => _prefs.WantsSsg08(p.SteamID)).ToList();
+
+    if (candidates.Count == 0) return Array.Empty<ulong>();
+    if (candidates.Count <= perTeam) return candidates.Select(p => p.SteamID).ToList();
+
+    var selected = new List<ulong>(perTeam);
+    var pool = candidates.ToList();
+    for (var i = 0; i < perTeam && pool.Count > 0; i++)
+    {
+      var idx = _random.Next(pool.Count);
+      selected.Add(pool[idx].SteamID);
+      pool.RemoveAt(idx);
+    }
+
+    return selected;
+  }
+
+  private IEnumerable<ulong> PickSsg08HalfBuyReceivers(List<IPlayer> players)
+  {
+    var perTeam = Math.Clamp(_ssg08HalfPerTeam.Value, 0, 10);
+    if (perTeam <= 0) return Array.Empty<ulong>();
+
+    if (players.Count == 0) return Array.Empty<ulong>();
+
+    var candidates = _ssg08HalfAllowEveryone.Value
+      ? players
+      : players.Where(p => _prefs.WantsSsg08HalfBuy(p.SteamID)).ToList();
 
     if (candidates.Count == 0) return Array.Empty<ulong>();
     if (candidates.Count <= perTeam) return candidates.Select(p => p.SteamID).ToList();

--- a/src/Services/ConVarApplicator.cs
+++ b/src/Services/ConVarApplicator.cs
@@ -40,6 +40,11 @@ public sealed class ConVarApplicator
     ApplyInt("retakes_allocation_ssg08_per_team", config.Allocation.Ssg08PerTeam);
     ApplyBool("retakes_allocation_ssg08_allow_everyone", config.Allocation.Ssg08AllowEveryone);
 
+    // SSG08 (half-buy) settings
+    ApplyBool("retakes_allocation_ssg08_half_enabled", config.Allocation.Ssg08HalfEnabled);
+    ApplyInt("retakes_allocation_ssg08_half_per_team", config.Allocation.Ssg08HalfPerTeam);
+    ApplyBool("retakes_allocation_ssg08_half_allow_everyone", config.Allocation.Ssg08HalfAllowEveryone);
+
     // AWP priority settings
     ApplyString("retakes_allocation_awp_priority_flag", config.Allocation.AwpPriorityFlag);
     ApplyInt("retakes_allocation_awp_priority_pct", config.Allocation.AwpPriorityPct);

--- a/src/Services/DatabaseService.cs
+++ b/src/Services/DatabaseService.cs
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS {UserSettingsTable} (
   updated_at BIGINT NOT NULL,
   wants_awp TINYINT NOT NULL DEFAULT 0,
   wants_ssg08 TINYINT NOT NULL DEFAULT 0,
+  wants_ssg08_half TINYINT NOT NULL DEFAULT 0,
   wants_awp_priority TINYINT NOT NULL DEFAULT 0,
   wants_ct_spawn_menu TINYINT NOT NULL DEFAULT 1,
   t_spawn_a INT NULL,
@@ -69,6 +70,7 @@ CREATE TABLE IF NOT EXISTS {UserSettingsTable} (
 
       // Add columns that may not exist in older schemas
       TryAddColumn(connection, UserSettingsTable, "wants_ssg08 TINYINT NOT NULL DEFAULT 0");
+      TryAddColumn(connection, UserSettingsTable, "wants_ssg08_half TINYINT NOT NULL DEFAULT 0");
       TryAddColumn(connection, UserSettingsTable, "wants_awp_priority TINYINT NOT NULL DEFAULT 0");
       TryAddColumn(connection, UserSettingsTable, "wants_ct_spawn_menu TINYINT NOT NULL DEFAULT 1");
       TryAddColumn(connection, UserSettingsTable, "t_spawn_a INT NULL");

--- a/src/Services/PlayerPreferencesService.cs
+++ b/src/Services/PlayerPreferencesService.cs
@@ -14,6 +14,7 @@ public sealed class PlayerPreferencesService : IPlayerPreferencesService
 
   private const string KeyWantsAwp = "retakes_wants_awp";
   private const string KeyWantsSsg08 = "retakes_wants_ssg08";
+  private const string KeyWantsSsg08HalfBuy = "retakes_wants_ssg08_half";
   private const string KeyWantsAwpPriority = "retakes_wants_awp_priority";
   private const string KeyWantsCtSpawnMenu = "retakes_wants_ct_spawn_menu";
   private const string KeyTSpawnA = "retakes_t_spawn_a";
@@ -67,6 +68,16 @@ public sealed class PlayerPreferencesService : IPlayerPreferencesService
   {
     var val = !WantsSsg08(steamId);
     SetBool(steamId, KeyWantsSsg08, val);
+    return val;
+  }
+
+  public bool WantsSsg08HalfBuy(ulong steamId) =>
+    GetBool(steamId, KeyWantsSsg08HalfBuy, false);
+
+  public bool ToggleSsg08HalfBuy(ulong steamId)
+  {
+    var val = !WantsSsg08HalfBuy(steamId);
+    SetBool(steamId, KeyWantsSsg08HalfBuy, val);
     return val;
   }
 


### PR DESCRIPTION
- `!awp or !gun awp` and `!scout / !ssg08 or !gun scout / !gun ssg08` will now both act as "set preference" command and not as "change current weapon to this weapon"
  - Previously this would cause 2 messages to be sent, 1 for preference set and 2nd for "this gun is not allowed to be given"
- Added SSG08 as `Half-Buy` and `Full-Buy` round preference